### PR TITLE
format jsons some, make defaults importable

### DIFF
--- a/btax/__init__.py
+++ b/btax/__init__.py
@@ -1,0 +1,1 @@
+from btax.parameters import DEFAULTS, DEFAULT_ASSET_COLS, DEFAULT_INDUSTRY_COLS

--- a/btax/param_defaults/btax_defaults.json
+++ b/btax/param_defaults/btax_defaults.json
@@ -16,13 +16,11 @@
     "btax_betr_entity_Switch",
     {
       "long_name": "Non-corporate Entity Level Income Tax Indicator",
-      "notes": "This parameter is an indicator for a entity-level tax on
-                non-C corporate entities, such as one would find under a
-                comprehensive business income tax (CBIT) system.",
+      "notes": "This parameter is an indicator for an entity-level tax on non-C corporate entities, such as one would find under a comprehensive business income tax (CBIT) system.",
       "description": "Indicator for non-corporate income tax.",
       "value": [
         [
-          False
+          false
         ]
       ]
     }
@@ -31,8 +29,7 @@
     "btax_betr_pass",
     {
       "long_name": "Non-corporate Entity Level Income Tax Rate",
-      "notes": "This parameter is the statutory income tax rate on non-C corporate
-                entities at the entity-level.",
+      "notes": "This parameter is the statutory income tax rate on non-C corporate entities at the entity-level.",
       "description": "Non-corporate entity-level income tax.",
       "value": [
         [
@@ -45,12 +42,10 @@
     "btax_depr_10yr_ads_Switch",
     {
       "long_name": "ADS on 10-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 10-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 10-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 10-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 10-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -58,9 +53,8 @@
     "btax_depr_10yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 10-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 10-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 10-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 10-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 10-year class  property.",
       "value": [
         50
       ]
@@ -70,27 +64,21 @@
     "btax_depr_10yr_gds_Switch",
     {
       "long_name": "GDS on 10-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 10-year class property.",
-      "description": "Indicator for General Depreciation System on 10-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 10-year class  property.",
+      "description": "Indicator for General Depreciation  System on 10-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_10yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 10-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 10-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 10-year
-                    class property.",
+      "long_name": "Economic depr eciation on 10-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 10-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 10-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -98,12 +86,10 @@
     "btax_depr_15yr_ads_Switch",
     {
       "long_name": "ADS on 15-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 15-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 15-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 15-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 15-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -111,9 +97,8 @@
     "btax_depr_15yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 10-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 15-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 15-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 15-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 15-year class  property.",
       "value": [
         50
       ]
@@ -123,27 +108,21 @@
     "btax_depr_15yr_gds_Switch",
     {
       "long_name": "GDS on 15-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 15-year class property.",
-      "description": "Indicator for General Depreciation System on 15-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 15-year class  property.",
+      "description": "Indicator for General Depreciation  System on 15-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_15yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 15-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 15-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 15-year
-                    class property.",
+      "long_name": "Economic depr eciation on 15-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 15-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 15-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -151,12 +130,10 @@
     "btax_depr_20yr_ads_Switch",
     {
       "long_name": "ADS on 20-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 20-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 20-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 20-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 20-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -164,9 +141,8 @@
     "btax_depr_20yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 20-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 20-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 20-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 20-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 20-year class  property.",
       "value": [
         50
       ]
@@ -176,27 +152,21 @@
     "btax_depr_20yr_gds_Switch",
     {
       "long_name": "GDS on 20-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 20-year class property.",
-      "description": "Indicator for General Depreciation System on 20-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 20-year class  property.",
+      "description": "Indicator for General Depreciation  System on 20-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_20yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 20-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 20-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 20-year
-                    class property.",
+      "long_name": "Economic depr eciation on 20-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 20-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 20-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -204,12 +174,10 @@
     "btax_depr_25yr_ads_Switch",
     {
       "long_name": "ADS on 10-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 25-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 25-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 25-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 25-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -217,9 +185,8 @@
     "btax_depr_25yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 25-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 25-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 25-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 25-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 25-year class  property.",
       "value": [
         0
       ]
@@ -229,27 +196,21 @@
     "btax_depr_25yr_gds_Switch",
     {
       "long_name": "GDS on 25-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 25-year class property.",
-      "description": "Indicator for General Depreciation System on 25-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 25-year class  property.",
+      "description": "Indicator for General Depreciation  System on 25-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_25yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 25-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 25-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 25-year
-                    class property.",
+      "long_name": "Economic depr eciation on 25-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 25-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 25-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -257,12 +218,10 @@
     "btax_depr_27_5yr_ads_Switch",
     {
       "long_name": "ADS on 27.5-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 27.5-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 27.5-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 27.5-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 27.5-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -270,9 +229,8 @@
     "btax_depr_27_5yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 27.5-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 27.5-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 27.5-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 27.5-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 27.5-year class  property.",
       "value": [
         0
       ]
@@ -282,27 +240,21 @@
     "btax_depr_27_5yr_gds_Switch",
     {
       "long_name": "GDS on 27.5-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 27.5-year class property.",
-      "description": "Indicator for General Depreciation System on 27.5-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 27.5-year class  property.",
+      "description": "Indicator for General Depreciation  System on 27.5-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_27_5yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 27.5-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 27.5-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 27.5-year
-                    class property.",
+      "long_name": "Economic depr eciation on 27.5-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 27.5-year class  property.  This means that the tax  depreciation schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 27.5-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -310,12 +262,10 @@
     "btax_depr_39yr_ads_Switch",
     {
       "long_name": "ADS on 39-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 39-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 39-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 39-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 39-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -323,9 +273,8 @@
     "btax_depr_39yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 39-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 39-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 39-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 39-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 39-year class  property.",
       "value": [
         0
       ]
@@ -335,27 +284,21 @@
     "btax_depr_39yr_gds_Switch",
     {
       "long_name": "GDS on 39-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 39-year class property.",
-      "description": "Indicator for General Depreciation System on 39-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 39-year class  property.",
+      "description": "Indicator for General Depreciation  System on 39-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_39yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 39-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 39-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 39-year
-                    class property.",
+      "long_name": "Economic depr eciation on 39-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 39-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 39-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -363,12 +306,10 @@
     "btax_depr_3yr_ads_Switch",
     {
       "long_name": "ADS on 3-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 3-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 3-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 3-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 3-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -376,9 +317,8 @@
     "btax_depr_3yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 3-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 3-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 3-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 3-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 3-year class  property.",
       "value": [
         50
       ]
@@ -388,27 +328,21 @@
     "btax_depr_3yr_gds_Switch",
     {
       "long_name": "GDS on 3-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 3-year class property.",
-      "description": "Indicator for General Depreciation System on 3-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 3-year class  property.",
+      "description": "Indicator for General Depreciation  System on 3-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_3yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 3-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 3-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 3-year
-                    class property.",
+      "long_name": "Economic depr eciation on 3-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 3-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 3-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -416,12 +350,10 @@
     "btax_depr_5yr_ads_Switch",
     {
       "long_name": "ADS on 5-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 5-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 5-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 5-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 5-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -429,9 +361,8 @@
     "btax_depr_5yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 5-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 5-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 5-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 5-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 5-year class  property.",
       "value": [
         50
       ]
@@ -441,27 +372,21 @@
     "btax_depr_5yr_gds_Switch",
     {
       "long_name": "GDS on 3-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 5-year class property.",
-      "description": "Indicator for General Depreciation System on 5-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 5-year class  property.",
+      "description": "Indicator for General Depreciation  System on 5-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_5yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 5-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 5-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 5-year
-                    class property.",
+      "long_name": "Economic depr eciation on 5-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 5-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 5-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -469,12 +394,10 @@
     "btax_depr_7yr_ads_Switch",
     {
       "long_name": "ADS on 7-year property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on 7-year class property.",
-      "description": "Indicator for Alternative Depreciation System on 7-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on 7-year class  property.",
+      "description": "Indicator for Alternative Depr eciation System on 7-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -482,9 +405,8 @@
     "btax_depr_7yr_exp",
     {
       "long_name": "Rate of bonus depreciation on 7-year property",
-      "notes": "This parameter gives the rate of bonus depreciation on 7-year
-                class property.  A rate of 100% results in full expensing.",
-      "description": "Rate of bonus depreciation on 7-year class property.",
+      "notes": "This parameter gives the rate of bonus depreciation on 7-year class  property.  A rate of 100% results in full expensing.",
+      "description": "Rate of bonus depreciation on 7-year class  property.",
       "value": [
         50
       ]
@@ -494,27 +416,21 @@
     "btax_depr_7yr_gds_Switch",
     {
       "long_name": "GDS on 7-year property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on 7-year class property.",
-      "description": "Indicator for General Depreciation System on 7-year
-                    class property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on 7-year class  property.",
+      "description": "Indicator for General Depreciation  System on 7-year class  property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_7yr_tax_Switch",
     {
-      "long_name": "Economic depreciation on 7-year property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on 7-year class property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on 7-year
-                    class property.",
+      "long_name": "Economic depr eciation on 7-year property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on 7-year class  property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on 7-year class  property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -522,12 +438,10 @@
     "btax_depr_allyr_ads_Switch",
     {
       "long_name": "ADS on all classes of property",
-      "notes": "This parameter is an indicator for the use of the Alternative
-                Depreciation System (ADS) on all classes of property.",
-      "description": "Indicator for Alternative Depreciation System on all
-                    classes of property.",
+      "notes": "This parameter is an indicator for the use of the Alternative Depr eciation System (ADS) on all classes of property.",
+      "description": "Indicator for Alternative Depr eciation System on all classes of property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -535,8 +449,7 @@
     "btax_depr_allyr_exp",
     {
       "long_name": "Rate of bonus depreciation on all classes of property",
-      "notes": "This parameter gives the rate of bonus depreciation on all
-                classes of property.  A rate of 100% results in full expensing.",
+      "notes": "This parameter gives the rate of bonus depreciation on all classes of property.  A rate of 100% results in full expensing.",
       "description": "Rate of bonus depreciation on all classes of property.",
       "value": [
         0
@@ -547,27 +460,21 @@
     "btax_depr_allyr_gds_Switch",
     {
       "long_name": "GDS on all classes of property",
-      "notes": "This parameter is an indicator for the use of the General
-                Depreciation System (GDS) on all classes of property.",
-      "description": "Indicator for General Depreciation System on all
-                    classes of property.",
+      "notes": "This parameter is an indicator for the use of the General Depreciation  System (GDS) on all classes of property.",
+      "description": "Indicator for General Depreciation  System on all classes of property.",
       "value": [
-        True
+        true
       ]
     }
   ],
   [
     "btax_depr_allyr_tax_Switch",
     {
-      "long_name": "Economic depreciation on alll classes of property",
-      "notes": "This parameter is an indicator for the use of the economic
-               depreciation on all classes of property.  This means that the
-               tax depreciatin schedule for each asset is set equal to the
-               BEA's estimated rate of economic depreciation.",
-      "description": "Indicator for economic depreciation on all
-                    classes of property.",
+      "long_name": "Economic depr eciation on alll classes of property",
+      "notes": "This parameter is an indicator for the use of the economic depr eciation on all classes of property.  This means that the tax  depreciatin schedule for each asset is set equal to the BEA 's estimated rate of economic depr eciation.",
+      "description": "Indicator for economic depr eciation on all classes of property.",
       "value": [
-        False
+        false
       ]
     }
   ],
@@ -575,8 +482,7 @@
     "btax_econ_inflat",
     {
       "long_name": "Inflation rate",
-      "notes": "The default inflation rate is determined by the forecast of the
-                Congressional Budget Office (CBO).",
+      "notes": "The default inflation rate is determined by the forecast of the Congressional Budget Office (CBO).",
       "description": "The inflation rate.",
       "value": [
         [
@@ -589,8 +495,7 @@
     "btax_econ_nomint",
     {
       "long_name": "Nominal Interest Rate",
-      "notes": "The default nominal interest rate is taken as the yeild on BBB
-                corporate bonds.",
+      "notes": "The default nominal interest rate is taken as the yeild on BBB corporate bonds.",
       "description": "The nominal interest rate paid on business debt.",
       "value": [
         [
@@ -603,12 +508,7 @@
     "btax_other_corpeq",
     {
       "long_name": "Allowance for corporate equity",
-      "notes": "This parameter gives the allowance for corporate equity (ACE).
-                Under an ACE system, companies can deduct a notional interest
-                on their equity.  The default rate used in B-Tax is the nominal
-                interest rate on corporate debt.  Moving this parameter up from
-                zero allows the corporate to have partial to full deductibility
-                of the notional interest on equity.",
+      "notes": "This parameter gives the allowance for corporate equity (ACE). Under an ACE system, companies can deduct a notional interest on their equity.  The default rate used in B-Tax is the nominal interest rate on corporate debt.  Moving this parameter up from zero allows the corporate to have partial to full deductibility of the notional interest on equity.",
       "description": "Allowance for corporate equity.",
       "value": [
         [
@@ -621,8 +521,7 @@
     "btax_other_hair",
     {
       "long_name": "Haircut on interest deductibility",
-      "notes": "This parameter gives the fraction of interest payments that are
-                not allowable as deductions against corporate income.",
+      "notes": "This parameter gives the fraction of interest payments that are not allowable as deductions against corporate income.",
       "description": "Haircut on interest deductibility.",
       "value": [
         [
@@ -635,9 +534,7 @@
     "btax_other_invest",
     {
       "long_name": "Investment tax credit rate",
-      "notes": "The investment tax credit rate gives the rate at which the cost
-                of new investments are credited against the firm's tax
-                liability.",
+      "notes": "The investment tax credit rate gives the rate at which the cost of new investments are credited against the firm's tax liability.",
       "description": "Investment tax credit rate.",
       "value": [
         [

--- a/btax/param_defaults/btax_results_by_asset.json
+++ b/btax/param_defaults/btax_results_by_asset.json
@@ -17,69 +17,52 @@
   "rho_c": {
     "col_label": "Cost of capital, typically financed corporate investment",
     "name": "rho_c",
-    "tooltip": "Cost of capital, corporate investment financed with historical
-                mix of debt and equity."
+    "tooltip": "Cost of capital, corporate investment financed with historical mix of debt and equity."
   },
   "metr_nc": {
     "col_label": "Cost of capital, typically financed non-corporate investment",
     "name": "metr_nc",
-    "tooltip": "Cost of capital, non-corporate investment financed with
-                historical mix of debt and equity."
+    "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity."
   },
   "z_c_d": {
-    "col_label": "NPV of depreciation deductions, corporate debt financed
-                  investment",
+    "col_label": "NPV of depreciation deductions, corporate debt financed investment",
     "name": "z_c_d",
-    "tooltip": "Net Present value of depreciation deductions, corporate debt
-                financed investment"
+    "tooltip": "Net Present value of depreciation deductions, corporate debt financed investment"
   },
   "z_c_e": {
-    "col_label": "NPV of depreciation deductions, corporate equity financed
-                  investment",
+    "col_label": "NPV of depreciation deductions, corporate equity financed investment",
     "name": "z_c_e",
-    "tooltip": "Net Present value of depreciation deductions, corporate equity
-                financed investment"
+    "tooltip": "Net Present value of depreciation deductions, corporate equity financed investment"
   },
   "mettr_c_d": {
-    "col_label": "METR, corporate debt financed
-                  investment",
+    "col_label": "METR, corporate debt financed investment",
     "name": "mettr_c_d",
-    "tooltip": "Marginal Effective Tax Rate on new investments, corporate debt
-                financed investment"
+    "tooltip": "Marginal Effective Tax Rate on new investments, corporate debt financed investment"
   },
   "rho_nc": {
     "col_label": "Cost of capital, typically financed non-corporate investment",
     "name": "rho_nc",
-    "tooltip": "Cost of capital, non-corporate investment financed with historical
-                mix of debt and equity."
+    "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity."
   },
   "z_nc": {
-    "col_label": "NPV of depreciation deductions, non-corporate typically financed
-                  investment",
+    "col_label": "NPV of depreciation deductions, non-corporate typically financed investment",
     "name": "z_nc",
-    "tooltip": "Net Present value of depreciation deductions, non-corporate
-                investment financed by historical mix of debt and equity."
+    "tooltip": "Net Present value of depreciation deductions, non-corporate investment financed by historical mix of debt and equity."
   },
   "mettr_c": {
-    "col_label": "METTR, corporate typically financed
-                  investment",
+    "col_label": "METTR, corporate typically financed investment",
     "name": "mettr_c",
-    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate
-                investment financed by historical mix of debt and equity."
+    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate investment financed by historical mix of debt and equity."
   },
   "z_c": {
-    "col_label": "NPV of depreciation deductions, corporate typically financed
-                  investment",
+    "col_label": "NPV of depreciation deductions, corporate typically financed investment",
     "name": "z_c",
-    "tooltip": "Net Present value of depreciation deductions, corporate
-                investment financed by historical mix of debt and equity."
+    "tooltip": "Net Present value of depreciation deductions, corporate investment financed by historical mix of debt and equity."
   },
   "mettr_nc": {
-    "col_label": "METTR, non-corporate typically financed
-                  investment",
+    "col_label": "METTR, non-corporate typically financed investment",
     "name": "mettr_nc",
-    "tooltip": "Marginal Effective Total Tax Rate on new investments, non-corporate
-                investment financed by historical mix of debt and equity."
+    "tooltip": "Marginal Effective Total Tax Rate on new investments, non-corporate investment financed by historical mix of debt and equity."
   },
   "delta": {
     "col_label": "Economic Depreciation Rate",
@@ -87,31 +70,23 @@
     "tooltip": "Economic Depreciation Rate"
   },
   "mettr_c_e": {
-    "col_label": "METTR, corporate equity financed
-                  investment",
+    "col_label": "METTR, corporate equity financed investment",
     "name": "mettr_c_e",
-    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate
-                equity financed investment."
+    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate equity financed investment."
   },
   "metr_c": {
-    "col_label": "METTR, corporate typically financed
-                  investment",
+    "col_label": "METTR, corporate typically financed investment",
     "name": "mettr_c",
-    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate
-                investment financed by historical mix of debt and equity."
+    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate investment financed by historical mix of debt and equity."
   },
   "metr_c_e": {
-    "col_label": "METR, corporate equity financed
-                  investment",
+    "col_label": "METR, corporate equity financed investment",
     "name": "metr_c_e",
-    "tooltip": "Marginal Effective Tax Rate on new investments, corporate
-                equity financed investment."
+    "tooltip": "Marginal Effective Tax Rate on new investments, corporate equity financed investment."
   },
   "metr_c_d": {
-    "col_label": "METR, corporate debt financed
-                  investment",
+    "col_label": "METR, corporate debt financed investment",
     "name": "metr_c_e",
-    "tooltip": "Marginal Effective Tax Rate on new investments, corporate
-                debt financed investment."
+    "tooltip": "Marginal Effective Tax Rate on new investments, corporate debt financed investment."
   }
 }

--- a/btax/param_defaults/btax_results_by_industry.json
+++ b/btax/param_defaults/btax_results_by_industry.json
@@ -22,42 +22,31 @@
   "rho_c": {
     "col_label": "Cost of capital, typically financed corporate investment",
     "name": "rho_c",
-    "tooltip": "Cost of capital, corporate investment financed with historical
-                mix of debt and equity."
-  },
-
+    "tooltip": "Cost of capital, corporate investment financed with historical mix of debt and equity."
   },
   "rho_nc": {
     "col_label": "Cost of capital, typically financed non-corporate investment",
     "name": "rho_nc",
-    "tooltip": "Cost of capital, non-corporate investment financed with historical
-                mix of debt and equity."
+    "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity."
   },
   "metr_nc": {
     "col_label": "Cost of capital, typically financed non-corporate investment",
     "name": "metr_nc",
-    "tooltip": "Cost of capital, non-corporate investment financed with
-                historical mix of debt and equity."
+    "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity."
   },
   "metr_c": {
-    "col_label": "METTR, corporate typically financed
-                  investment",
+    "col_label": "METTR, corporate typically financed investment",
     "name": "mettr_c",
-    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate
-                investment financed by historical mix of debt and equity."
+    "tooltip": "Marginal Effective Total Tax Rate on new investments, corporate investment financed by historical mix of debt and equity."
   },
   "metr_c_e": {
-    "col_label": "METR, corporate equity financed
-                  investment",
+    "col_label": "METR, corporate equity financed investment",
     "name": "metr_c_e",
-    "tooltip": "Marginal Effective Tax Rate on new investments, corporate
-                equity financed investment."
+    "tooltip": "Marginal Effective Tax Rate on new investments, corporate equity financed investment."
   },
   "metr_c_d": {
-    "col_label": "METR, corporate debt financed
-                  investment",
+    "col_label": "METR, corporate debt financed investment",
     "name": "metr_c_e",
-    "tooltip": "Marginal Effective Tax Rate on new investments, corporate
-                debt financed investment."
+    "tooltip": "Marginal Effective Tax Rate on new investments, corporate debt financed investment."
   }
 }

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -3,11 +3,20 @@ Parameters (parameters.py):
 -------------------------------------------------------------------------------
 
 This module contains all the parameters used for the calc_final_outputs.py script. It also
-contains intermediate calculations that produce more relevant parameters. The parameters 
+contains intermediate calculations that produce more relevant parameters. The parameters
 are placed in a dictionary. Last Updated 7/27/2016
 """
+import json
+import os
+
 from calc_z import calc_tax_depr_rates, get_econ_depr
 import numpy as np
+
+from btax.util import read_from_egg
+
+DEFAULTS = json.loads(read_from_egg(os.path.join('param_defaults', 'btax_defaults.json')))
+DEFAULT_ASSET_COLS = json.loads(read_from_egg(os.path.join('param_defaults', 'btax_results_by_asset.json')))
+DEFAULT_INDUSTRY_COLS = json.loads(read_from_egg(os.path.join('param_defaults', 'btax_results_by_industry.json')))
 
 def get_params():
 	"""Contains all the parameters


### PR DESCRIPTION
This PR does some formatting on the jsons but does not change the content (just getting rid of multi line strings).  It also makes it possible to do:
`from btax import DEFAULTS`

and get the contents of `btax_defaults.json` as a Python object.