### PR TITLE
Clean up, Script to run particular reform

### DIFF
--- a/btax/btax_reform_run.py
+++ b/btax/btax_reform_run.py
@@ -1,0 +1,10 @@
+"""
+Runs a paricular reform against the baseline policy:
+-------------------------------------------------------------------------------
+"""
+# Import packages
+from btax.run_btax import run_btax_with_baseline_delta as run_btax
+
+# run btax
+run_btax(btax_betr_pass=0.23, btax_betr_corp=0.25, btax_depr_allyr_exp=1.,
+         btax_other_hair=1.)

--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -117,10 +117,16 @@ def industry_calcs(params, asset_data, output_by_asset):
     # merge cost of capital, depreciation rates by asset
     df2 = output_by_asset[['bea_asset_code', 'delta','z_c','z_c_d','z_c_e','z_nc', 'z_nc_d',
                         'z_nc_e', 'rho_c','rho_c_d','rho_c_e','rho_nc',
-                        'rho_nc_d', 'rho_nc_e']].copy()
+                        'rho_nc_d', 'rho_nc_e','asset_category']].copy()
     by_industry_asset = pd.merge(bea, df2, how='left', left_on=['bea_asset_code'],
       right_on=['bea_asset_code'], left_index=False, right_index=False, sort=False,
       copy=True)
+
+    # drop Intellectual Property - not sure have it straight and CBO not include
+    by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Intellectual Property'].copy()
+    by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Land'].copy()
+    by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Inventories'].copy()
+
 
     # create weighted averages by industry/tax treatment
     by_industry_tax = pd.DataFrame({'delta' : by_industry_asset.groupby(
@@ -157,9 +163,8 @@ def industry_calcs(params, asset_data, output_by_asset):
     non_corp.rename(columns={"delta": "delta_nc","assets": "assets_nc"},inplace=True)
     by_industry = pd.merge(corp, non_corp, how='inner', on=['bea_ind_code'],
                            left_index=False, right_index=False, sort=False,copy=True)
-
     # merge in industry names
-    df3 = asset_data[['Industry','bea_ind_code']]
+    df3 = asset_data[['Industry','bea_ind_code']].copy()
     df3.drop_duplicates(inplace=True)
     by_industry = pd.merge(by_industry, df3, how='left', left_on=['bea_ind_code'],
       right_on=['bea_ind_code'], left_index=False, right_index=False, sort=False,

--- a/btax/calc_z.py
+++ b/btax/calc_z.py
@@ -51,7 +51,6 @@ def calc_tax_depr_rates(r, delta, bonus_deprec, deprec_system, tax_methods, fina
 
     # update tax_deprec_rates based on user defined parameters
     tax_deprec_rates['System'] = tax_deprec_rates['GDS'].apply(str_modified)
-    tax_deprec_rates.to_csv('testDF6.csv',encoding='utf-8')
     tax_deprec_rates['System'].replace(deprec_system,inplace=True)
 
     # add bonus depreciation to tax deprec parameters dataframe
@@ -98,7 +97,6 @@ def npv_tax_deprec(df, r, tax_methods, financing_list, entity_list):
     # append gds and ads results
     df_all = df_gds.append(df_ads.append(df_econ,ignore_index=True), ignore_index=True)
 
-    df_all.to_csv('testDF3.csv',encoding='utf-8')
     return df_all
 
 def dbsl(df, r, financing_list, entity_list):

--- a/btax/data/depreciation_rates/Economic Depreciation Rates.csv
+++ b/btax/data/depreciation_rates/Economic Depreciation Rates.csv
@@ -1,15 +1,15 @@
 Code,Asset,Economic Depreciation Rate
-EP1A,Mainframes,0.3
-EP1B,PCs,0.11
-EP1C,DASDs,0.28
-EP1D,Printers,0.35
-EP1E,Terminals,0.27
-EP1F,Tape drives,0.28
-EP1G,Storage devices,0.28
-EP1H,System integrators,0.3
+EP1A,Mainframes,0.4633
+EP1B,PCs,0.4633
+EP1C,DASDs,0.4633
+EP1D,Printers,0.4633
+EP1E,Terminals,0.4633
+EP1F,Tape drives,0.4633
+EP1G,Storage devices,0.4633
+EP1H,System integrators,0.4633
 EP20,Communications,0.1129
 EP34,Nonelectro medical instruments,0.135
-EP35,Electro medical instruments,0.1834
+EP35,Electro medical instruments,0.135
 EP36,Nonmedical instruments,0.135
 EP31,Photocopy and related equipment,0.18
 EP12,Office and accounting equipment,0.3119
@@ -17,11 +17,11 @@ EI11,Nuclear fuel,0.25
 EI12,Other fabricated metals,0.0917
 EI21,Steam engines,0.0516
 EI22,Internal combustion engines,0.2063
-EI30,Metalworking machinery,0.1031
-EI40,Special industrial machinery,0.15
-EI50,General industrial equipment,0.15
+EI30,Metalworking machinery,0.1225
+EI40,Special industrial machinery,0.1031
+EI50,General industrial equipment,0.1072
 EI60,Electric transmission and distribution,0.05
-ET11,Light trucks (including utility vehicles),0.1925
+ET11,Light trucks (including utility vehicles),0.1725
 ET12,"Other trucks, buses and truck trailers",0.1725
 ET20,Autos,0.3333
 ET30,Aircraft,0.0859
@@ -44,13 +44,13 @@ SB32,Special care,0.0188
 SOO2,Medical buildings,0.0247
 SC03,Multimerchandise shopping,0.0262
 SC04,Food and beverage establishments,0.0262
-SC01,Warehouses,0.0222
+SC01,Warehouses,0.0225
 SOMO ,Mobile structures,0.0556
 SC02,Other commercial,0.0262
 SI00,Manufacturing,0.0314
 SU30,Electric,0.0211
 SU60,Wind and solar,0.0303
-SU40,Gas,0.0237
+SU40,Gas,0.0751
 SU50,Petroleum pipelines,0.0237
 SU20,Communication,0.0237
 SM01,Petroleum and natural gas,0.0751

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -42,10 +42,12 @@ def translate_param_names(**user_mods):
         elif 'btax_depr_'+cl+'yr_tax_Switch':
             user_deprec_system[cl] = 'Economic'
 
-    user_bonus_deprec = {cl: user_mods['btax_depr_{}yr_exp'.format(cl)]/100.
-    			 for cl in class_list_str}
+    # user_bonus_deprec = {cl: user_mods['btax_depr_{}yr_exp'.format(cl)]/100.
+    # 			 for cl in class_list_str}
     # to zero out bonus - useful for compare to CBO
-    # user_bonus_deprec = {cl: 0.for cl in class_list_str}
+    user_bonus_deprec = {cl: 0.for cl in class_list_str}
+    # for expensing
+    # user_bonus_deprec = {cl: 1.for cl in class_list_str}
 
 
     if user_mods['btax_betr_entity_Switch'] in (True, 'True'):
@@ -110,7 +112,7 @@ def get_params(**user_mods):
     pi = user_params['pi']
     i = user_params['i']
     u_c = user_params['u_c']
-    u_nc = user_params['u_nc']
+    u_nc = 0.33 #0.331 # CBO(2014) user_params['u_nc']
     u_array = np.array([u_c, u_nc])
     w = user_params['w']
     inv_credit = user_params['inv_credit']
@@ -128,11 +130,11 @@ def get_params(**user_mods):
     bonus_deprec['100'] = 0.
     deprec_system['100'] = 'ADS'
 
-    tau_nc = 0.331 # tax rate on non-corporate business income
-    tau_div = 0.184 # tax rate on dividend income
-    tau_int = 0.274 # tax rate on interest income
-    tau_scg = 0.323 # tax rate on short term capital gains
-    tau_lcg = 0.212 # tax rate on long term capital gains
+    tau_nc = 0.33 # 0.331 # tax rate on non-corporate business income
+    tau_div = 0.1757 #0.184 # tax rate on dividend income
+    tau_int = 0.2379 # 0.274 # tax rate on interest income
+    tau_scg = 0.3131 #0.323 # tax rate on short term capital gains
+    tau_lcg = 0.222 #0.212 # tax rate on long term capital gains
     tau_xcg = 0.00 # tax rate on capital gains held to death
     tau_td = 0.215 # tax rate on return to equity held in tax defferred accounts
     tau_h = 0.181 # tax rate owner occupied housing deductions

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -74,18 +74,9 @@ def run_btax(**user_params):
     output_by_asset = calc_final_outputs.asset_calcs(parameters,asset_data)
     pickle.dump( output_by_asset, open( "by_asset.pkl", "wb" ) )
 
-    # check against CBO
-    format_output.CBO_compare(output_by_asset)
-
     # make calculations by industry and create formated output
     output_by_industry = calc_final_outputs.industry_calcs(parameters, asset_data, output_by_asset)
 
-    # create plots
-    # by asset
-    visuals.asset_crossfilter(output_by_asset)
-    #visuals_plotly.asset_bubble(output_by_asset)
-
-    # print output_by_industry.head(n=50)
 
     return output_by_asset, output_by_industry
 
@@ -98,6 +89,21 @@ def run_btax_with_baseline_delta(**user_params):
                                             base_output_by_asset)
     delta_output_by_industry = diff_two_tables(reform_output_by_industry,
                                                base_output_by_industry)
+
+    # create plots
+    # by asset
+    visuals.asset_crossfilter(base_output_by_asset,'baseline')
+    visuals.asset_crossfilter(reform_output_by_asset,'reform')
+    #visuals_plotly.asset_bubble(output_by_asset)
+
+    # save output to csv - useful if run locally
+    base_output_by_industry.to_csv('baseline_byindustry.csv',encoding='utf-8')
+    reform_output_by_industry.to_csv('reform_byindustry.csv',encoding='utf-8')
+    base_output_by_asset.to_csv('base_byasset.csv',encoding='utf-8')
+    reform_output_by_asset.to_csv('reform_byasset.csv',encoding='utf-8')
+
+
+
     return ModelDiffs(base_output_by_asset,
                       reform_output_by_asset,
                       delta_output_by_asset,

--- a/btax/visuals.py
+++ b/btax/visuals.py
@@ -72,7 +72,7 @@ Plot results
 SIZES = list(range(6, 22, 3))
 COLORS = Reds9
 
-def asset_crossfilter(output_by_assets):
+def asset_crossfilter(output_by_assets,baseline):
     """Creates a crossfilter bokeh plot of results by asset
 
         :output_by_assets: Contains output by asset
@@ -132,7 +132,7 @@ def asset_crossfilter(output_by_assets):
     plot = curdoc()
     #plot.circle([1,2], [3,4])
     html = file_html(plot, CDN, "my plot")
-    file = open("crossfilter_html.html","wb") #open file in binary mode
+    file = open(baseline+"crossfilter_html.html","wb") #open file in binary mode
     file.writelines(html)
     file.close()
 


### PR DESCRIPTION
This PR cleans up the code - moving the saving of visual and tabular output to run_btax.run_btax_with_baseline_delta, which seems more appropriate.   It also fixes a set with copy warning and adds a script to run a particular reform (which can be used as an example for running other reforms locally).

Finally, some depreciation rates are updated to be more consistent with CBO numbers.