### PR TITLE
Fix units

### DIFF
--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -124,8 +124,8 @@ def industry_calcs(params, asset_data, output_by_asset):
 
     # drop Intellectual Property - not sure have it straight and CBO not include
     by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Intellectual Property'].copy()
-    by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Land'].copy()
-    by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Inventories'].copy()
+    #by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Land'].copy()
+    #by_industry_asset = by_industry_asset[by_industry_asset['asset_category']!='Inventories'].copy()
 
 
     # create weighted averages by industry/tax treatment

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -21,6 +21,7 @@ globals().update(get_paths())
 
 # Constant factors:
 _BEA_IN_FILE_FCTR = 10**6
+_BEA_INV_RES_FCTR = 10**9
 _FIN_ACCT_FILE_FCTR = 10**9
 _START_POS = 8
 _SKIP1 = 47
@@ -116,6 +117,7 @@ def inventories(soi_data):
     bea_inventories.rename(columns={"Unnamed: 1":"bea_inv_name",
                                "IV.1": "BEA Inventories"},inplace=True)
     bea_inventories['bea_inv_name'] = bea_inventories['bea_inv_name'].str.strip()
+    bea_inventories['BEA Inventories'] = bea_inventories['BEA Inventories']*_BEA_INV_RES_FCTR
 
     # Merge inventories data to SOI data
     bea_inventories = pd.merge(bea_inventories,soi_data,how='right', left_on=['bea_inv_name'],
@@ -148,7 +150,7 @@ def land(soi_data, bea_FA):
     bea_residential = bea_residential[[u'\xa0','2013']].copy()
     bea_residential.rename(columns={u"\xa0":"entity_type",
                                "2013": "Fixed Assets"},inplace=True)
-    bea_residential['Fixed Assets'] *= _FIN_ACCT_FILE_FCTR
+    bea_residential['Fixed Assets'] *= _BEA_INV_RES_FCTR
     bea_residential['entity_type'] = bea_residential['entity_type'].str.strip()
     owner_occ_house_FA = np.array(bea_residential.ix[bea_residential['entity_type']=='Households','Fixed Assets'])
     corp_res_FA = np.array(bea_residential.ix[bea_residential['entity_type']=='Corporate','Fixed Assets'])
@@ -264,8 +266,5 @@ def combine(fixed_assets,inventories,land,res_assets,owner_occ_dict):
     asset_data = pd.merge(asset_data, bea_ind_names, how='left', on=['bea_ind_code'],
       left_index=False, right_index=False, sort=False,
       copy=True)
-
-    # save result to pickle so don't have to do this everytime
-    pickle.dump(asset_data, open( "asset_data.pkl", "wb" ) )
 
     return asset_data

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -64,6 +64,8 @@ def run_btax(**user_params):
         land, res_assets, owner_occ_dict = read_bea.land(soi_data, fixed_assets)
         # put all asset data together
         asset_data = read_bea.combine(fixed_assets,inventories,land,res_assets,owner_occ_dict)
+        # save result to pickle so don't have to do this everytime
+        pickle.dump(asset_data, open( "asset_data.pkl", "wb" ) )
     else:
         asset_data = pickle.load(open('asset_data.pkl', 'rb'))
 


### PR DESCRIPTION
This PR makes the units consistent across the various SOI, BEA, and Fin Accounts data sources.  With consistent accounting now confirmed, land and inventories are included in the calculations of METRs by industry.