### PR TITLE
Psteinberg/versioneer tables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,4 @@
 # ``shelve``, ``marshal``, ``anydbm``, & ``bsddb``
 # (among others).
 
+btax/_version.py export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,5 @@ include btax/data/raw_data/soi/soi_corporate/*.csv
 include btax/data/raw_data/soi/soi_partner/*.csv
 include btax/data/raw_data/soi/soi_proprietorship/*.csv
 include btax/data/raw_data/*.csv
-include btax/param_defaults/*.json
+include btax/param_defaults/*.jsoninclude versioneer.py
+include btax/_version.py

--- a/btax/__init__.py
+++ b/btax/__init__.py
@@ -1,2 +1,6 @@
 from btax.parameters import DEFAULTS, DEFAULT_ASSET_COLS, DEFAULT_INDUSTRY_COLS
 from btax import _version
+
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions

--- a/btax/_version.py
+++ b/btax/_version.py
@@ -37,8 +37,8 @@ def get_config():
     cfg.VCS = "git"
     cfg.style = "pep440"
     cfg.tag_prefix = ""
-    cfg.parentdir_prefix = "vst-"
-    cfg.versionfile_source = "vst/_version.py"
+    cfg.parentdir_prefix = "None"
+    cfg.versionfile_source = "btax/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/btax/param_defaults/btax_results_by_asset.json
+++ b/btax/param_defaults/btax_results_by_asset.json
@@ -13,7 +13,7 @@
       {
         "col_label": "METR, corporate typically financed investment",
         "name": "mettr_c",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, corporate investment financed by historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -24,7 +24,7 @@
       {
         "col_label": "METR, non-corporate typically financed investment",
         "name": "mettr_c",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -35,7 +35,7 @@
       {
         "col_label": "METR, corporate equity financed investment",
         "name": "metr_c_e",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -46,7 +46,7 @@
       {
         "col_label": "METR, non-corporate equity financed investment",
         "name": "metr_nc_e",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, non-corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -57,7 +57,7 @@
       {
         "col_label": "METR, corporate debt financed investment",
         "name": "metr_c_d",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, corporate debt financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -68,7 +68,7 @@
        {
          "col_label": "METR, non-corporate debt financed investment",
          "name": "metr_nc_d",
-         "table_id": "effective_tax",
+         "table_id": "metr",
          "tooltip": "Marginal effective tax rate on new investments, non-corporate debt financed investment.",
          "divisor": 1,
          "decimals": 3
@@ -79,7 +79,7 @@
        {
          "col_label": "METTR, corporate typically financed investment",
          "name": "mettr_c",
-         "table_id": "total_tax",
+         "table_id": "mettr",
          "tooltip": "Marginal effective total tax rate on new investments, corporate investment financed by historical mix of debt and equity.",
          "divisor": 1,
          "decimals": 3
@@ -90,7 +90,7 @@
       {
         "col_label": "METTR, non-corporate typically financed investment",
         "name": "mettr_nc",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -101,7 +101,7 @@
       {
         "col_label": "METTR, corporate equity financed investment",
         "name": "mettr_c_e",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -112,7 +112,7 @@
       {
         "col_label": "METTR, non-corporate equity financed investment",
         "name": "mettr_nc_e",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, non-corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -123,7 +123,7 @@
       {
         "col_label": "METTR, corporate debt financed investment",
         "name": "mettr_c_e",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, corporate debt financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -134,7 +134,7 @@
       {
         "col_label": "METTR, non-corporate debt financed investment",
         "name": "mettr_c_e",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective total tax rate on new investments, non-corporate debt financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -145,7 +145,7 @@
       {
         "col_label": "Cost of capital, typically financed corporate investment",
         "name": "rho_c",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, corporate investment financed with historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -156,7 +156,7 @@
         {
           "col_label": "Cost of capital, typically financed non-corporate investment",
           "name": "rho_nc",
-          "table_id": "cost_of_cap",
+          "table_id": "coc",
           "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity.",
           "divisor": 1,
           "decimals": 3
@@ -167,7 +167,7 @@
       {
         "col_label": "Cost of capital, equity financed corporate investment",
         "name": "rho_c_e",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -178,7 +178,7 @@
       {
         "col_label": "Cost of capital, equity financed non-corporate investment",
         "name": "rho_c_e",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -189,7 +189,7 @@
       {
         "col_label": "Cost of capital, debt financed corporate investment",
         "name": "rho_c_d",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -200,7 +200,7 @@
       {
         "col_label": "Cost of capital, debt financed non-corporate investment",
         "name": "rho_nc_d",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -211,7 +211,7 @@
       {
         "col_label": "NPV of depreciation deductions, typically financed corporate investment",
         "name": "z_c",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, corporate investment financed with historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -222,7 +222,7 @@
         {
           "col_label": "NPV of depreciation deductions, typically financed non-corporate investment",
           "name": "z_nc",
-          "table_id": "deprec",
+          "table_id": "d",
           "tooltip": "NPV of depreciation deductions, non-corporate investment financed with historical mix of debt and equity.",
           "divisor": 1,
           "decimals": 3
@@ -233,7 +233,7 @@
       {
         "col_label": "NPV of depreciation deductions, equity financed corporate investment",
         "name": "rho_c_e",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -244,7 +244,7 @@
       {
         "col_label": "NPV of depreciation deductions, equity financed non-corporate investment",
         "name": "z_c_e",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -255,7 +255,7 @@
       {
         "col_label": "NPV of depreciation deductions, debt financed corporate investment",
         "name": "z_c_d",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -266,7 +266,7 @@
       {
         "col_label": "NPV of depreciation deductions, debt financed non-corporate investment",
         "name": "z_nc_d",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -277,7 +277,7 @@
       {
         "col_label": "Economic depreciation rate",
         "name": "delta",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "Economic depreciation rate",
         "divisor": 1,
         "decimals": 3

--- a/btax/param_defaults/btax_results_by_industry.json
+++ b/btax/param_defaults/btax_results_by_industry.json
@@ -13,7 +13,7 @@
       {
         "col_label": "METR, corporate typically financed investment",
         "name": "mettr_c",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, corporate investment financed by historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -24,7 +24,7 @@
       {
         "col_label": "METR, non-corporate typically financed investment",
         "name": "mettr_c",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -35,7 +35,7 @@
       {
         "col_label": "METR, corporate equity financed investment",
         "name": "metr_c_e",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -46,7 +46,7 @@
       {
         "col_label": "METR, non-corporate equity financed investment",
         "name": "metr_nc_e",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, non-corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -57,7 +57,7 @@
       {
         "col_label": "METR, corporate debt financed investment",
         "name": "metr_c_d",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective tax rate on new investments, corporate debt financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -68,7 +68,7 @@
        {
          "col_label": "METR, non-corporate debt financed investment",
          "name": "metr_nc_d",
-         "table_id": "effective_tax",
+         "table_id": "metr",
          "tooltip": "Marginal effective tax rate on new investments, non-corporate debt financed investment.",
          "divisor": 1,
          "decimals": 3
@@ -79,7 +79,7 @@
        {
          "col_label": "METTR, corporate typically financed investment",
          "name": "mettr_c",
-         "table_id": "total_tax",
+         "table_id": "mettr",
          "tooltip": "Marginal effective total tax rate on new investments, corporate investment financed by historical mix of debt and equity.",
          "divisor": 1,
          "decimals": 3
@@ -90,7 +90,7 @@
       {
         "col_label": "METTR, non-corporate typically financed investment",
         "name": "mettr_nc",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -101,7 +101,7 @@
       {
         "col_label": "METTR, corporate equity financed investment",
         "name": "mettr_c_e",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -112,7 +112,7 @@
       {
         "col_label": "METTR, non-corporate equity financed investment",
         "name": "mettr_nc_e",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, non-corporate equity financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -123,7 +123,7 @@
       {
         "col_label": "METTR, corporate debt financed investment",
         "name": "mettr_c_e",
-        "table_id": "total_tax",
+        "table_id": "mettr",
         "tooltip": "Marginal effective total tax rate on new investments, corporate debt financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -134,7 +134,7 @@
       {
         "col_label": "METTR, non-corporate debt financed investment",
         "name": "mettr_c_e",
-        "table_id": "effective_tax",
+        "table_id": "metr",
         "tooltip": "Marginal effective total tax rate on new investments, non-corporate debt financed investment.",
         "divisor": 1,
         "decimals": 3
@@ -145,7 +145,7 @@
       {
         "col_label": "Cost of capital, typically financed corporate investment",
         "name": "rho_c",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, corporate investment financed with historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -156,7 +156,7 @@
         {
           "col_label": "Cost of capital, typically financed non-corporate investment",
           "name": "rho_nc",
-          "table_id": "cost_of_cap",
+          "table_id": "coc",
           "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity.",
           "divisor": 1,
           "decimals": 3
@@ -167,7 +167,7 @@
       {
         "col_label": "Cost of capital, equity financed corporate investment",
         "name": "rho_c_e",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -178,7 +178,7 @@
       {
         "col_label": "Cost of capital, equity financed non-corporate investment",
         "name": "rho_c_e",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -189,7 +189,7 @@
       {
         "col_label": "Cost of capital, debt financed corporate investment",
         "name": "rho_c_d",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -200,7 +200,7 @@
       {
         "col_label": "Cost of capital, debt financed non-corporate investment",
         "name": "rho_nc_d",
-        "table_id": "cost_of_cap",
+        "table_id": "coc",
         "tooltip": "Cost of capital, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -211,7 +211,7 @@
       {
         "col_label": "NPV of depreciation deductions, typically financed corporate investment",
         "name": "z_c",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, corporate investment financed with historical mix of debt and equity.",
         "divisor": 1,
         "decimals": 3
@@ -222,7 +222,7 @@
         {
           "col_label": "NPV of depreciation deductions, typically financed non-corporate investment",
           "name": "z_nc",
-          "table_id": "deprec",
+          "table_id": "d",
           "tooltip": "NPV of depreciation deductions, non-corporate investment financed with historical mix of debt and equity.",
           "divisor": 1,
           "decimals": 3
@@ -233,7 +233,7 @@
       {
         "col_label": "NPV of depreciation deductions, equity financed corporate investment",
         "name": "rho_c_e",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -244,7 +244,7 @@
       {
         "col_label": "NPV of depreciation deductions, equity financed non-corporate investment",
         "name": "z_c_e",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by equity",
         "divisor": 1,
         "decimals": 3
@@ -255,7 +255,7 @@
       {
         "col_label": "NPV of depreciation deductions, debt financed corporate investment",
         "name": "z_c_d",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -266,7 +266,7 @@
       {
         "col_label": "NPV of depreciation deductions, debt financed non-corporate investment",
         "name": "z_nc_d",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "NPV of depreciation deductions, investment financed 100% by debt",
         "divisor": 1,
         "decimals": 3
@@ -277,7 +277,7 @@
       {
         "col_label": "Economic depreciation rate, corporate sector",
         "name": "delta_c",
-        "table_id": "deprec",
+        "table_id": "d",
         "tooltip": "Economic depreciation rate",
         "divisor": 1,
         "decimals": 3
@@ -288,7 +288,7 @@
     {
       "col_label": "Economic depreciation rate, non-corporate sector",
       "name": "delta_nc",
-      "table_id": "deprec",
+      "table_id": "d",
       "tooltip": "Economic depreciation rate",
       "divisor": 1,
       "decimals": 3

--- a/btax/util.py
+++ b/btax/util.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import numbers
 import os
 from pkg_resources import resource_stream, Requirement
@@ -114,7 +114,7 @@ def str_modified(i):
 
 def _dataframe_to_json_table(df, defaults, label, index_col):
     groups = [x[1]['table_id'] for x in defaults]
-    tables = {}
+    tables = defaultdict(lambda: {})
     for group in set(groups):
         if group == 'all':
             continue
@@ -127,7 +127,14 @@ def _dataframe_to_json_table(df, defaults, label, index_col):
         df2.columns = new_column_names
         header = list(df2.columns)
         rows = [[k,] + list(v) for k, v in df2.T.iteritems()]
-        tables['{}_{}'.format(label, group)] = [header] + rows
+        if 'reform' in label:
+            label2 = 'reform'
+        elif 'changed' in label:
+            label2 = 'changed'
+        elif 'base' in label:
+            label2 = 'baseline'
+        print(label, label2, group)
+        tables[group][label2] = [header] + rows
     return tables
 
 def output_by_asset_to_json_table(df, table_name):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[pytest]
+pep8ignore = E402
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = btax/_version.py
+versionfile_build = btax/_version.py
+tag_prefix = 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import glob
 import os
 
-VERSION = '0.1'
+import versioneer
 
 try:
 	from setuptools import setup
@@ -16,8 +16,9 @@ def get_data_files():
     files += glob.glob(os.path.join('btax', 'param_defaults', '*.json'))
     return [os.path.relpath(f, 'btax') for f in files]
 
-setup(name='btax',
-	  version=VERSION,
+setup(    version=versioneer.get_version(),
+          cmdclass=versioneer.get_cmdclass(),
+          name='btax',
 	  description ='Business tax calculator',
 	  long_description = 'Calculates the marginal effective tax rate and marginal effective total tax rate by asset type',
 	  classifiers =[
@@ -28,10 +29,10 @@ setup(name='btax',
 	  author_email='bfgard@gmail.com',
 	  url='https://github.com/open-source-economics/B-Tax',
 	  packages=['btax'],
-      package_data={'btax': get_data_files()},
+          package_data={'btax': get_data_files()},
 	  install_requires=[],
-      entry_points={
-        'console_scripts': [
-            'run-btax = btax.run_btax:main',
-       ]}
+          entry_points={
+          'console_scripts': [
+              'run-btax = btax.run_btax:main',
+          ]}
 )


### PR DESCRIPTION
* [x] Makes sure `versioneer` is imported and referenced in `setup.py`
* [x] Changes to support B-Tax json table formatting
* [x] Bug fix on `asset_data.pkl` not being found unless B-Tax has been run