### PR TITLE
Fix ads gds tax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ install:
 script:
   #- run-btax                    # ensure the pickles are updated
   - python -c "from btax.run_btax import run_btax_to_json_tables;run_btax_to_json_tables(test_run=True,start_year=2016,iit_reform={},btax_betr_corp=0.2,btax_betr_entity_Switch=True, btax_betr_pass=.3)"
+  - py.test -m "not slow"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install -r requirements.txt
   #- conda install -c ospc taxcalc
   - git clone https://github.com/jdebacker/Tax-Calculator.git && cd Tax-Calculator
-  - git fetch --all && git checkout master && python setup.py install && $BUILD_DIR
+  - git fetch --all && git checkout master && python setup.py install && cd $BUILD_DIR
   - export BTAX_OUT_DIR=btax_output_dir # make an output dir
   - export BTAX_CUR_DIR=${BUILD_DIR}/btax
   - mkdir btax_output_dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,15 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pandas numpy
   - source activate test-environment
   - conda install --file conda-requirements.txt # xlrd, possibly others
+  - export BUILD_DIR=`pwd`
   - pip install -r requirements.txt
   #- conda install -c ospc taxcalc
   - git clone https://github.com/jdebacker/Tax-Calculator.git && cd Tax-Calculator
-  - git fetch --all && git checkout master && python setup.py install && cd ..
+  - git fetch --all && git checkout master && python setup.py install && $BUILD_DIR
   - export BTAX_OUT_DIR=btax_output_dir # make an output dir
-  - export BTAX_CUR_DIR=btax
+  - export BTAX_CUR_DIR=${BUILD_DIR}/btax
   - mkdir btax_output_dir
-  - python setup.py install
+  - python setup.py develop
 
 script:
   #- run-btax                    # ensure the pickles are updated

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ install:
 script:
   #- run-btax                    # ensure the pickles are updated
   - python -c "from btax.run_btax import run_btax_to_json_tables;run_btax_to_json_tables(test_run=True,start_year=2016,iit_reform={},btax_betr_corp=0.2,btax_betr_entity_Switch=True, btax_betr_pass=.3)"
-  - py.test -m "not slow"
+  - py.test -m "not slow" ${BTAX_CUR_DIR}/tests
+

--- a/btax/param_defaults/btax_defaults.json
+++ b/btax/param_defaults/btax_defaults.json
@@ -540,7 +540,7 @@
     {
       "long_name": "Haircut on interest deductibility",
       "notes": "This parameter gives the fraction of interest payments that are not allowable as deductions against corporate income.",
-      "description": "Haircut on interest deductibility (fractin of interst deductible)",
+      "description": "Haircut on interest deductibility (fraction of interest deductible)",
       "value": [
           0.0
       ],

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -29,20 +29,21 @@ def translate_param_names(**user_mods):
     # btax_betr_entity_Switch # If this parameter =True, then u_nc default to corp rate
 
     defaults = dict(DEFAULTS)
-    user_mods.update({k: v['value'][0] for k,v in defaults.iteritems()})
     radio_tags = ('gds', 'ads', 'tax',)
     class_list = [3, 5, 7, 10, 15, 20, 25, 27.5, 39]
     class_list_str = [(str(i) if i != 27.5 else '27_5') for i in class_list]
     user_deprec_system = {}
-
     for cl in class_list_str:
-        if 'btax_depr_'+cl+'yr_gds_Switch':
+        if user_mods.get('btax_depr_'+cl+'yr_gds_Switch'):
             user_deprec_system[cl] = 'GDS'
-        elif 'btax_depr_'+cl+'yr_ads_Switch':
+        elif user_mods.get('btax_depr_'+cl+'yr_ads_Switch'):
             user_deprec_system[cl] = 'ADS'
-        elif 'btax_depr_'+cl+'yr_tax_Switch':
+        elif user_mods.get('btax_depr_'+cl+'yr_tax_Switch'):
             user_deprec_system[cl] = 'Economic'
-
+        else:
+            user_deprec_system[cl] = 'GDS'
+    user_mods.update({k: v['value'][0] for k,v in defaults.iteritems()
+                      if k not in user_mods})
     # user_bonus_deprec = {cl: user_mods['btax_depr_{}yr_exp'.format(cl)]/100.
     # 			 for cl in class_list_str}
     # to zero out bonus - useful for compare to CBO

--- a/btax/tests/test_params_have_effect.py
+++ b/btax/tests/test_params_have_effect.py
@@ -21,7 +21,8 @@ def tst_once(**user_params):
     assert has_changed
 
 
-@pytest.mark.parametrize('k,v', DEFAULTS)
+@pytest.mark.parametrize('k,v', [(k,v) for k,v in DEFAULTS
+                                  if not ('depr' in k and not 'Switch' in k)])
 @pytest.mark.slow
 def test_each_param_has_effect(k, v):
     '''For each parameter in param_defaults/btax_default.json,

--- a/btax/tests/test_params_have_effect.py
+++ b/btax/tests/test_params_have_effect.py
@@ -1,0 +1,51 @@
+import pytest
+
+from btax.parameters import DEFAULTS, get_params, translate_param_names
+from btax.run_btax import run_btax_to_json_tables
+
+def tst_once(**user_params):
+    tables = run_btax_to_json_tables(**user_params)
+    has_changed = False
+    for k in tables:
+        changed = tables[k]['changed']
+
+        for row in changed:
+            for item in row:
+                if isinstance(item, (float, int)) and item:
+                    has_changed = True
+                    break
+            if has_changed:
+                break
+        if has_changed:
+            break
+    assert has_changed
+
+
+@pytest.mark.parametrize('k,v', DEFAULTS)
+@pytest.mark.slow
+def test_each_param_has_effect(k, v):
+    '''For each parameter in param_defaults/btax_default.json,
+    assert that changing the parameter has at least once
+    change in the changes tables relative to baseline.
+    (Slower-running test)'''
+    default = v['value'][0]
+    # come up with a reasonable non-default value to put in
+    if isinstance(default, bool):
+        val = not default
+    elif v.get('min') and v.get('max'):
+        val = (v['max'][0] + v['min'][0]) / 2.1
+    elif isinstance(default, int):
+        val = default + 1
+    else:
+        val = default + 0.05
+    # Run it with one parameter in non-default mode
+    tst_once(**{k: val})
+
+
+def test_gds_ads_econ_switch():
+    params = translate_param_names(btax_depr_10yr_ads_Switch=True)
+    assert params['deprec_system']['10'] == 'ADS'
+    params = translate_param_names()
+    assert params['deprec_system']['10'] == 'GDS'
+    params = translate_param_names(btax_depr_10yr_tax_Switch=True)
+    assert params['deprec_system']['10'] == 'Economic'

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -5,3 +5,4 @@ numba
 six
 toolz
 pandas>=0.18
+pytest


### PR DESCRIPTION
* [x] Fixes ignored check boxes in the user's depreciation system (GDS, ADS, Economic) by moving around several lines in `translate_param_names`
* [x] Adds a test of depreciation parameter name translation (fast running test which can run in CI)
* [ ] Adds a set of slower tests that test when each parameter is modified (by itself), at least one of the results' change-vs-baseline tables has at least one non-zero entry.  @jdebacker can you confirm that this is a reasonable goal: should each parameter in param_defaults/btax_defaults.json have an effect on at least one "changed" table when run as a single changed parameter?  If so, I think there is further test follow up to do in separate PRs. Also can you run `py.test -m "slow" -v` and investigate why parameters may not have an effect?  We need more test coverage on this repo.