### PR TITLE
fix shallow copy issue with tables

### DIFF
--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -119,18 +119,24 @@ def run_btax_with_baseline_delta(test_run,start_year,iit_reform,**user_params):
 
 def run_btax_to_json_tables(test_run=False,start_year=2016,iit_reform=None, **user_params):
     out = run_btax_with_baseline_delta(test_run,start_year,iit_reform,**user_params)
-    tables = defaultdict(lambda: {})
+    tables = {}
     for table_name, table in zip(TABLE_ORDER, out):
         if 'asset' in table_name:
             tab = output_by_asset_to_json_table(table, table_name)
             for k, v in tab.items():
                 for k2, v2 in v.items():
-                    tables['asset_{}'.format(k)][k2] = v2
+                    k1 = 'asset_{}'.format(k)
+                    if not k1 in tables:
+                        tables[k1] = {}
+                    tables[k1][k2] = v2
         elif 'industry' in table_name:
             tab = output_by_industry_to_json_table(table, table_name)
             for k, v in tab.items():
                 for k2, v2 in v.items():
-                    tables['industry_{}'.format(k)][k2] = v2
+                    k1 = 'industry_{}'.format(k)
+                    if not k1 in tables:
+                        tables[k1] = {}
+                    tables[k1][k2] = v2
         else:
             raise ValueError('Expected an "asset" or "industry" related table')
     return dict(tables)

--- a/btax/tests/test_params_have_effect.py
+++ b/btax/tests/test_params_have_effect.py
@@ -22,7 +22,7 @@ def tst_once(**user_params):
 
 
 @pytest.mark.parametrize('k,v', [(k,v) for k,v in DEFAULTS
-                                  if not ('depr' in k and not 'Switch' in k)])
+                                  if not ('depr' in k and 'Switch' in k)])
 @pytest.mark.slow
 def test_each_param_has_effect(k, v):
     '''For each parameter in param_defaults/btax_default.json,


### PR DESCRIPTION
There was an issue with shallow copies in the dictionary resulting in the reform being the same as baseline.  

The bug is shown here in @brendancol 's screenshot:

<img width="482" alt="screen shot 2016-09-12 at 3 06 51 pm" src="https://cloud.githubusercontent.com/assets/1445602/18452270/102bc1d0-78ef-11e6-994c-3b3cf45977c4.png">

And with the fix:
<img width="544" alt="screen shot 2016-09-12 at 1 38 44 pm" src="https://cloud.githubusercontent.com/assets/1445602/18452320/3bda3726-78ef-11e6-8668-dfe868881d22.png">

