### PR TITLE
Fix missing values for total assets

### DIFF
--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -46,7 +46,6 @@ def asset_calcs(params,asset_data):
     # initialize dataframe - start w/ z output
     output_by_asset = z.copy()
 
-
     # calculate the cost of capital, metr, mettr
     for i in range(save_rate.shape[0]):
         for j in range(save_rate.shape[1]):
@@ -68,6 +67,7 @@ def asset_calcs(params,asset_data):
     # create asset category variable
     output_by_asset['asset_category'] = output_by_asset['Asset Type']
     output_by_asset['asset_category'].replace(asset_dict,inplace=True)
+    output_by_asset.to_csv('out_test.csv',encoding='utf-8')
 
     # merge in dollar value of assets - sep for corp and non-corp
     # should be able to do this better with pivot table

--- a/btax/calc_z.py
+++ b/btax/calc_z.py
@@ -31,6 +31,7 @@ def get_econ_depr():
     econ_deprec_rates.rename(columns={"Code": "bea_asset_code",
                         "Economic Depreciation Rate": "delta"},inplace=True)
     econ_deprec_rates['Asset'] = econ_deprec_rates['Asset'].str.strip()
+    econ_deprec_rates['bea_asset_code'] = econ_deprec_rates['bea_asset_code'].str.strip()
 
     return econ_deprec_rates
 

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -214,7 +214,7 @@ def land(soi_data, bea_FA):
     bea_res_assets['assets'] = bea_res_assets['res_FA_ratio']*bea_res_assets['BEA Res Assets']
     # create new asset category for residential structures
     bea_res_assets['Asset Type'] = 'Residential'
-    bea_res_assets['bea_asset_code'] = ''
+    bea_res_assets['bea_asset_code'] = 'RES'
     bea_res_assets = bea_res_assets[['Asset Type','bea_asset_code','bea_ind_code',
                                      'minor_code_alt','entity_type','tax_treat',
                                      'assets']].copy()

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -48,6 +48,7 @@ def fixed_assets(soi_data):
     bea_FA['assets'] = bea_FA['assets']*_BEA_IN_FILE_FCTR
     bea_FA['bea_asset_code'] = bea_FA.long_code.str[-6:-2]
     bea_FA['bea_ind_code'] = bea_FA.long_code.str[3:7]
+    bea_FA['bea_asset_code'] = bea_FA['bea_asset_code'].str.strip()
 
     # Read in BEA asset names
     bea_asset_names = pd.read_excel(_BEA_ASSET_PATH, sheetname="110C",

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -52,7 +52,7 @@ def run_btax(test_run,baseline=False,start_year=2016,iit_reform=None,**user_para
 	:returns: METR (by industry and asset) and METTR (by asset)
 	:rtype: DataFrame
     """
-    calc_assets = True
+    calc_assets = False
 
     iit_reform = iit_reform or {}
     if calc_assets or not os.path.exists(ASSET_PRE_CACHE_FILE):
@@ -81,7 +81,6 @@ def run_btax(test_run,baseline=False,start_year=2016,iit_reform=None,**user_para
 
     # make calculations by industry and create formated output
     output_by_industry = calc_final_outputs.industry_calcs(parameters, asset_data, output_by_asset)
-
 
     return output_by_asset, output_by_industry
 

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -52,7 +52,7 @@ def run_btax(test_run,baseline=False,start_year=2016,iit_reform=None,**user_para
 	:returns: METR (by industry and asset) and METTR (by asset)
 	:rtype: DataFrame
     """
-    calc_assets = False
+    calc_assets = True
 
     iit_reform = iit_reform or {}
     if calc_assets or not os.path.exists(ASSET_PRE_CACHE_FILE):


### PR DESCRIPTION
Two asset types were missing values for the total amount of assets: Residential buildings and mobile structures.  

This PR fixes the first by finding a missing value for the asset code.

The mobile structures missing value had to do with the value of the asset code not being stripped of all black space in a consistent way across datasets.
