### PR TITLE
Fix equation to determine bonus depreciation

### DIFF
--- a/btax/calc_z.py
+++ b/btax/calc_z.py
@@ -122,43 +122,18 @@ def dbsl(df, r, financing_list, entity_list):
     df['Y_star'] = ((((df['Y']-1)*(1-(1/df['b'])))*(df['bonus']!=0.)) +
                     ((1-(df['bonus']!=0.))*(df['Y']*(1-(1/df['b'])))))
 
-
     for i in range(r.shape[0]):
         for j in range(r.shape[1]):
-            # df['z1'+entity_list[j]+financing_list[i]] = \
-            #     (((df['beta']/(df['beta']+r[i,j]))*(1-np.exp(-1*(df['beta']
-            #         +r[i,j])*df['Y_star']))) +
-            #     ((np.exp(-1*df['beta']*df['Y_star'])/(((df['Y']-1)-
-            #     df['Y_star'])*r[i,j]))*(np.exp(-1*r[i,j]*df['Y_star'])-
-            #                             np.exp(-1*r[i,j]*(df['Y']-1))))).where(df['bonus']!=0.)
-            # df['z'+entity_list[j]+financing_list[i]] = \
-            #     ((df['bonus']+df['beta'] + ((1-(df['bonus']-df['beta']))*
-            #    (df['z1'+entity_list[j]+financing_list[i]]/(1+r[i,j]))))).where(df['bonus']!=0.)
-            # df['z'+entity_list[j]+financing_list[i]] = \
-            #     (((df['beta']/(df['beta']+r[i,j]))*(1-np.exp(-1*(df['beta']+r[i,j])*
-            #         df['Y_star']))) +
-            #     ((np.exp(-1*df['beta']*df['Y_star'])/((df['Y']-df['Y_star'])
-            #         *r[i,j]))*(np.exp(-1*r[i,j]*df['Y_star'])-np.exp(-1*r[i,j]*df['Y'])))).where(df['bonus']==0.)
-            df['z1'+entity_list[j]+financing_list[i]] = \
-                            (((((df['beta']/(df['beta']+r[i,j]))*(1-np.exp(-1*(df['beta']
-                                +r[i,j])*df['Y_star']))) +
-                            ((np.exp(-1*df['beta']*df['Y_star'])/(((df['Y']-1)-
-                            df['Y_star'])*r[i,j]))*(np.exp(-1*r[i,j]*df['Y_star'])-
-                                                    np.exp(-1*r[i,j]*(df['Y']-1))))))*(df['bonus']!=0.))
             df['z'+entity_list[j]+financing_list[i]] = \
-                            ((((df['bonus']+(df['beta']*(1-(df['bonus']))) + ((1-(df['bonus']+(df['beta']*(1-(df['bonus'])))))*
-                           (df['z1'+entity_list[j]+financing_list[i]]/(1+r[i,j])))))*(df['bonus']!=0.))
-                           + (((((df['beta']/(df['beta']+r[i,j]))*(1-np.exp(-1*(df['beta']+r[i,j])*
+                            df['bonus'] + ((1-df['bonus'])*(((df['beta']/(df['beta']+r[i,j]))*(1-np.exp(-1*(df['beta']+r[i,j])*
                                df['Y_star']))) +
                            ((np.exp(-1*df['beta']*df['Y_star'])/((df['Y']-df['Y_star'])
-                               *r[i,j]))*(np.exp(-1*r[i,j]*df['Y_star'])-np.exp(-1*r[i,j]*df['Y']))))
-                              *(1-(df['bonus']!=0.)))))
+                               *r[i,j]))*(np.exp(-1*r[i,j]*df['Y_star'])-np.exp(-1*r[i,j]*df['Y'])))))
 
-            # don't allow bonus to give NPV > 1
-            df.ix[df['z'+entity_list[j]+financing_list[i]] > 1., 'z'+entity_list[j]+financing_list[i]] = 1.
+            # # don't allow bonus to give NPV > 1
+            # df.ix[df['z'+entity_list[j]+financing_list[i]] > 1., 'z'+entity_list[j]+financing_list[i]] = 1.
 
-
-    df.drop(['z1_c', 'z1_c_d', 'z1_c_e', 'z1_nc', 'z1_nc_d', 'z1_nc_e', 'beta', 'Y', 'Y_star'], axis=1, inplace=True)
+    df.drop(['beta', 'Y', 'Y_star'], axis=1, inplace=True)
 
     return df
 
@@ -178,24 +153,13 @@ def sl(df, r, financing_list, entity_list):
     df['Y'] = df['ADS']
     for i in range(r.shape[0]):
         for j in range(r.shape[1]):
-            # df['z1'+entity_list[j]+financing_list[i]] = \
-            #     (np.exp(-1*r[i,j]*(df['Y']-1)/(r[i,j]*(df['Y']-1)))).where(df['bonus']!=0.)
-            # df['z'+entity_list[j]+financing_list[i]] = \
-            #     (df['bonus']+(1./df['Y']) + ((1-df['bonus']-(1./df['Y']))*
-            #    (df['z1'+entity_list[j]+financing_list[i]]/(1+r[i,j])))).where(df['bonus']!=0.)
-            # df['z'+entity_list[j]+financing_list[i]] = \
-            #     (np.exp(-1*r[i,j]*df['Y'])/(r[i,j]*df['Y'])).where(df['bonus']==0.)
-            df['z1'+entity_list[j]+financing_list[i]] = \
-                ((np.exp(-1*r[i,j]*(df['Y']-1)/(r[i,j]*(df['Y']-1))))*(df['bonus']!=0.))
             df['z'+entity_list[j]+financing_list[i]] = \
-                (((df['bonus']+((1./df['Y'])*(1-df['bonus'])) + ((1-(df['bonus']+((1./df['Y'])*(1-df['bonus']))))*
-               (df['z1'+entity_list[j]+financing_list[i]]/(1+r[i,j]))))*(df['bonus']!=0.))
-                + ((np.exp(-1*r[i,j]*df['Y'])/(r[i,j]*df['Y']))**(1-(df['bonus']!=0.))))
+                df['bonus'] + ((1-df['bonus'])*((np.exp(-1*r[i,j]*df['Y'])/(r[i,j]*df['Y']))))
 
-            # don't allow bonus to give NPV > 1
-            df.ix[df['z'+entity_list[j]+financing_list[i]] > 1., 'z'+entity_list[j]+financing_list[i]] = 1.
+            # # don't allow bonus to give NPV > 1
+            # df.ix[df['z'+entity_list[j]+financing_list[i]] > 1., 'z'+entity_list[j]+financing_list[i]] = 1.
 
-    df.drop(['z1_c', 'z1_c_d', 'z1_c_e', 'z1_nc', 'z1_nc_d', 'z1_nc_e', 'Y'], axis=1, inplace=True)
+    df.drop(['Y'], axis=1, inplace=True)
 
     return df
 
@@ -215,17 +179,10 @@ def econ(df, r, financing_list, entity_list):
     """
     for i in range(r.shape[0]):
         for j in range(r.shape[1]):
-            # df['z'+entity_list[j]+financing_list[i]] = \
-            #     (df['bonus']+(df['delta']) + ((1-df['bonus']-df['delta'])*
-            #    (df['delta']/((df['delta']+r[i,j])*(1+r[i,j]))))).where(df['bonus']!=0.)
-            # df['z'+entity_list[j]+financing_list[i]] = \
-            #     (df['delta']/(df['delta']+r[i,j])).where(df['bonus']==0.)
             df['z'+entity_list[j]+financing_list[i]] = \
-                (((df['bonus']+(df['delta']*(1-df['bonus'])) + ((1-(df['bonus']+(df['delta']*(1-df['bonus']))))*
-               (df['delta']/((df['delta']+r[i,j])*(1+r[i,j])))))*(df['bonus']!=0.))
-                + ((df['delta']/(df['delta']+r[i,j]))*(1-(df['bonus']==0.))))
+                df['bonus'] + ((1-df['bonus'])*((df['delta']/(df['delta']+r[i,j]))))
 
-            # don't allow bonus to give NPV > 1
-            df.ix[df['z'+entity_list[j]+financing_list[i]] > 1., 'z'+entity_list[j]+financing_list[i]] = 1.
+            # # don't allow bonus to give NPV > 1
+            # df.ix[df['z'+entity_list[j]+financing_list[i]] > 1., 'z'+entity_list[j]+financing_list[i]] = 1.
 
     return df

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -192,7 +192,6 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
     s_nc_e = E_nc
     s_nc = f_nc*s_nc_d + (1-f_nc)*s_nc_e
     s_array = np.array([[s_c, s_nc], [s_c_d, s_nc_d], [s_c_e, s_nc_e]])
-
     r = f_array*(i*(1-(1-int_haircut)*u_array))+(1-f_array)*(E_array+pi - E_array*r_ace*ace_array)
     r_prime = f_array*i+(1-f_array)*(E_array+pi)
     delta = get_econ_depr()


### PR DESCRIPTION
After reading [this paper](http://www-personal.umich.edu/~shapiro/bonus-depreciation.pdf) by Shapiro, I noticed the difference between metrs with and without bonus were too large.  After some investigation, I found that calc_z was not correctly handling bonus depreciation. 

This pull request corrects the calculation of the NPV of depreciation deductions in the presences of bonus.

 