### PR TITLE
Split assets by type of partner

### DIFF
--- a/btax/check_asset_alloc.py
+++ b/btax/check_asset_alloc.py
@@ -1,0 +1,210 @@
+"""
+Fixed Asset Breakdown (check_asset_alloc.py):
+-------------------------------------------------------------------------------
+
+This script reads in BEA, SOI, and and Financial Accounts data.
+It computes totals from these data and then compares those totals to
+objects produced from run_btax.  Differences are printed to the screen.
+In addition, a series of tables showing the split of assets between corporat
+and non-corporate tax treatement across industry are produced for comparison with
+similar tables from the CBO.
+
+Last updated 10/05/2016
+"""
+# Packages:
+import os.path
+import numpy as np
+import pandas as pd
+import xlrd
+import pickle
+from btax.util import get_paths
+
+# Directories:
+globals().update(get_paths())
+
+# Constant factors:
+_BEA_IN_FILE_FCTR = 10**6
+_BEA_INV_RES_FCTR = 10**9
+_FIN_ACCT_FILE_FCTR = 10**9
+_START_POS = 8
+_SKIP1 = 47
+_SKIP2 = 80
+_CORP_PRT = [1,2]
+_NCORP_PRT = [3,4,5,6,7,8,9,10]
+
+
+'''
+Find totals to compare to
+'''
+
+# Read in BEA fixed asset table
+bea_FA = pd.read_excel(_BEA_ASSET_PATH, sheetname="Datasets")
+bea_FA = bea_FA[['2013']]
+bea_FA['long_code'] = bea_FA.index
+bea_FA.dropna(subset = ['long_code'],inplace=True)
+bea_FA.reset_index(drop=True,inplace=True)
+bea_FA.rename(columns={"2013": "assets"},inplace=True)
+bea_FA['assets'] = bea_FA['assets']*_BEA_IN_FILE_FCTR
+bea_FA['bea_asset_code'] = bea_FA.long_code.str[-6:-2]
+bea_FA['bea_ind_code'] = bea_FA.long_code.str[3:7]
+bea_FA['bea_asset_code'] = bea_FA['bea_asset_code'].str.strip()
+# Read in BEA asset names
+bea_asset_names = pd.read_excel(_BEA_ASSET_PATH, sheetname="110C",
+            header=5, converters={'Asset Codes': str})
+bea_asset_names = bea_asset_names[['Asset Codes','NIPA Asset Types']]
+bea_asset_names.dropna(subset = ['Asset Codes'],inplace=True)
+bea_asset_names.rename(columns={"Asset Codes": "bea_asset_code", "NIPA Asset Types": "Asset Type"},inplace=True)
+bea_asset_names['bea_asset_code'] = bea_asset_names['bea_asset_code'].str.strip()
+bea_asset_names['Asset Type'] = bea_asset_names['Asset Type'].str.strip()
+# Merge asset names to asset data - this will leave out subtotals for different
+# categories (equipment, structure, IP)
+bea_FA = pd.merge(bea_FA, bea_asset_names, how='inner', on=['bea_asset_code'],
+  left_index=False, right_index=False, sort=False,
+  copy=True)
+# find total
+total_bea_FA = bea_FA['assets'].sum()
+
+
+
+# read in BEA inventories data
+bea_inventories = pd.read_excel(_BEA_INV, sheetname="Sheet0",skiprows=6, skip_footer=4)
+bea_inventories.reset_index()
+bea_inventories = bea_inventories[['Unnamed: 1','IV.1']].copy()
+bea_inventories.rename(columns={"Unnamed: 1":"bea_inv_name",
+                           "IV.1": "BEA Inventories"},inplace=True)
+bea_inventories['bea_inv_name'] = bea_inventories['bea_inv_name'].str.strip()
+bea_inventories['BEA Inventories'] = bea_inventories['BEA Inventories']*_BEA_INV_RES_FCTR
+total_bea_INV = bea_inventories.loc[bea_inventories['bea_inv_name']=='Private inventories 1','BEA Inventories'].values
+
+
+
+# Get totals for land
+# for now, don't read in land data from excel file since too simple, but need to update this
+# what fin accounts data is this from??
+corp_land = 2875.0*_FIN_ACCT_FILE_FCTR
+noncorp_land = 13792.4*_FIN_ACCT_FILE_FCTR
+total_finacct_LAND = corp_land + noncorp_land
+
+# Get totals for residential assets
+#read in BEA data on residential fixed assets
+bea_residential = pd.read_excel(_BEA_RES, sheetname="Sheet0",skiprows=5, skip_footer=2)
+bea_residential.reset_index()
+bea_residential = bea_residential[[u'\xa0','2013']].copy()
+bea_residential.rename(columns={u"\xa0":"entity_type",
+                           "2013": "Fixed Assets"},inplace=True)
+bea_residential['Fixed Assets'] *= _BEA_INV_RES_FCTR
+bea_residential['entity_type'] = bea_residential['entity_type'].str.strip()
+owner_occ_house_FA = np.array(bea_residential.ix[bea_residential['entity_type']=='Households','Fixed Assets'])
+corp_res_FA = np.array(bea_residential.ix[bea_residential['entity_type']=='Corporate','Fixed Assets'])
+noncorp_res_FA = np.array(bea_residential.ix[bea_residential['entity_type']=='Sole proprietorships and partnerships','Fixed Assets'])
+total_bea_RES_FA = owner_occ_house_FA + corp_res_FA + noncorp_res_FA
+
+# read in Financial Accounts data on total value of real estate in
+# owner occ sector (includes land and structures)
+b101 = pd.read_csv(_B101_PATH,header=5)
+b101.reset_index()
+b101 = b101[['Unnamed: 0','2013']].copy()
+b101.rename(columns={"Unnamed: 0":"Variable",
+                           "2013": "Value"},inplace=True)
+b101['Value'] *= _FIN_ACCT_FILE_FCTR
+b101['Variable'] = b101['Variable'].str.strip()
+owner_occ_house_RE = np.array(b101.ix[b101['Variable']==
+    'Households; owner-occupied real estate including vacant land and mobile homes at market value','Value'])
+
+# compute value of land for owner occupied housing sector
+owner_occ_house_land = owner_occ_house_RE - owner_occ_house_FA
+# update amout of land for non-corporate sector
+noncorp_land -= owner_occ_house_land
+
+
+'''
+Read in asset pickle ued by B-Tax and compare totals
+'''
+asset_data = pickle.load(open('asset_data.pkl', 'rb'))
+total_btax_assets = asset_data['assets'].sum()
+total_btax_LAND = asset_data.loc[asset_data['Asset Type']=='Land','assets'].sum()
+total_btax_INV = asset_data.loc[asset_data['Asset Type']=='Inventories','assets'].sum()
+total_btax_RES_FA = asset_data.loc[asset_data['Asset Type']=='Residential','assets'].sum()
+total_btax_FA = total_btax_assets - total_btax_LAND - total_btax_INV - total_btax_RES_FA
+print 'diff in FA: ', total_btax_RES_FA-total_bea_RES_FA
+
+
+'''
+Print percentage differences between control totals and BTax data
+'''
+print 'Diff in Non-residential Fixed Assets: ', (total_btax_FA-total_bea_FA)/total_bea_FA
+print 'Diff in Land: ', (total_btax_LAND-total_finacct_LAND)/total_finacct_LAND
+print 'Diff in Inventories: ', (total_btax_INV-total_bea_INV)/total_bea_INV
+print 'Diff in Residential Fixed Assets: ', (total_btax_RES_FA-total_bea_RES_FA)/total_bea_RES_FA
+
+print "amount non-res fixed assets: ", total_btax_FA
+print "amount of land: ", total_btax_LAND
+print "amount of inventories: ", total_btax_INV
+print "amount of res fixed assets: ", total_btax_RES_FA
+print "diff in res fixed assets: ", total_btax_RES_FA-total_bea_RES_FA
+'''
+Do differences in fixed assets by industry (the place where BEA data has detail)
+'''
+btax_FA = asset_data[asset_data['Asset Type']!='Land'].copy()
+btax_FA = btax_FA[btax_FA['Asset Type']!='Inventories'].copy()
+btax_FA = btax_FA[btax_FA['Asset Type']!='Land'].copy()
+btax_FA = btax_FA[btax_FA['Asset Type']!='Residential'].copy()
+bea_ind = pd.DataFrame(bea_FA.groupby('bea_ind_code').sum()).reset_index()
+btax_ind = pd.DataFrame(btax_FA.groupby('bea_ind_code').sum()).reset_index()
+FA_ind = pd.merge(bea_ind, btax_ind, how='left', left_on=['bea_ind_code'],
+  right_on=['bea_ind_code'], left_index=False, right_index=False, sort=False,
+  copy=True)
+FA_ind['difference'] = FA_ind['assets_x']-FA_ind['assets_y']
+FA_ind.to_csv('FixedAsset_DiffsByInd.csv',encoding='utf-8')
+
+
+'''
+Find shares of assets attributed to corp/non-corp by industry
+'''
+btax_FA['assets_nc'] = 0
+btax_FA['assets_c'] = 0
+btax_FA.loc[btax_FA['tax_treat']=='non-corporate','assets_nc']= btax_FA.loc[btax_FA['tax_treat']=='non-corporate','assets']
+btax_FA.loc[btax_FA['tax_treat']=='corporate','assets_c']= btax_FA.loc[btax_FA['tax_treat']=='corporate','assets']
+# shares_corp_non = pd.DataFrame({btax_FA.groupby(
+#     ['bea_ind_code'])['assets_c','assets_nc','assets'].sum()}).reset_index()
+shares_corp_non = pd.DataFrame(btax_FA.groupby(['bea_ind_code'])['assets_c','assets_nc','assets'].sum()).reset_index()
+shares_corp_non['Corp Share'] = shares_corp_non['assets_c']/(shares_corp_non['assets_c']+shares_corp_non['assets_nc'])
+shares_corp_non['Non-corp Share'] = shares_corp_non['assets_nc']/(shares_corp_non['assets_c']+shares_corp_non['assets_nc'])
+shares_corp_non['check'] = (shares_corp_non['assets_c']+shares_corp_non['assets_nc'])-shares_corp_non['assets']
+# merge in industry names
+df3 = asset_data[['Industry','bea_ind_code']].copy()
+df3.drop_duplicates(inplace=True)
+shares_corp_non = pd.merge(shares_corp_non, df3, how='left', left_on=['bea_ind_code'],
+  right_on=['bea_ind_code'], left_index=False, right_index=False, sort=False,
+  copy=True)
+shares_corp_non['Industry'] = shares_corp_non['Industry'].str.strip()
+# save to csv to look over/compare with CBO
+shares_corp_non.to_csv('shares_corp_non.csv',encoding='utf-8')
+
+'''
+Find shares of assets attributed to corp/non-corp partnerships by industry
+'''
+btax_FA = asset_data[asset_data['Asset Type']!='Land'].copy()
+btax_part_FA = btax_FA[btax_FA['entity_type']=='partnership'].copy()
+btax_part_FA = btax_part_FA[btax_part_FA['Asset Type']!='Inventories'].copy()
+btax_part_FA = btax_part_FA[btax_part_FA['Asset Type']!='Land'].copy()
+btax_part_FA = btax_part_FA[btax_part_FA['Asset Type']!='Residential'].copy()
+btax_part_FA['assets_nc'] = 0
+btax_part_FA['assets_c'] = 0
+btax_part_FA.loc[btax_part_FA['tax_treat']=='non-corporate','assets_nc']= btax_part_FA.loc[btax_part_FA['tax_treat']=='non-corporate','assets']
+btax_part_FA.loc[btax_part_FA['tax_treat']=='corporate','assets_c']= btax_part_FA.loc[btax_part_FA['tax_treat']=='corporate','assets']
+# shares_corp_non = pd.DataFrame({btax_FA.groupby(
+#     ['bea_ind_code'])['assets_c','assets_nc','assets'].sum()}).reset_index()
+part_corp_non = pd.DataFrame(btax_part_FA.groupby(['bea_ind_code'])['assets_c','assets_nc','assets'].sum()).reset_index()
+part_corp_non['Corp Share'] = part_corp_non['assets_c']/(part_corp_non['assets_c']+part_corp_non['assets_nc'])
+part_corp_non['Non-corp Share'] = part_corp_non['assets_nc']/(part_corp_non['assets_c']+part_corp_non['assets_nc'])
+part_corp_non['check'] = (part_corp_non['assets_c']+part_corp_non['assets_nc'])-part_corp_non['assets']
+# merge in industry names
+df3 = asset_data[['Industry','bea_ind_code']].copy()
+df3.drop_duplicates(inplace=True)
+part_corp_non = pd.merge(part_corp_non, df3, how='left', left_on=['bea_ind_code'],
+  right_on=['bea_ind_code'], left_index=False, right_index=False, sort=False,
+  copy=True)
+part_corp_non['Industry'] = part_corp_non['Industry'].str.strip()
+# save to csv to look over/compare with CBO
+part_corp_non.to_csv('part_corp_non.csv',encoding='utf-8')

--- a/btax/data/raw_data/soi/soi_partner/13pa05_Crosswalk.csv
+++ b/btax/data/raw_data/soi/soi_partner/13pa05_Crosswalk.csv
@@ -1,0 +1,33 @@
+Industry:,Codes:
+All industries,1
+"Agriculture, forestry, fishing, and hunting",11
+Mining,21
+Utilities,22
+Construction,23
+Manufacturing,31
+Wholesale trade,42
+Retail trade,44
+Transportation and warehousing,48
+Information,51
+Finance and insurance,52
+"Securities, commodity contracts and other financial investments and related activities",523
+Securities and commodity contracts and exchanges,523905
+Other financial investment activities,523905
+"Funds, trusts and other financial vehicles",525
+Other finance and insurance,524
+Real estate and rental and leasing,53
+Real estate,531
+Lessors of residential buildings and dwellings and cooperative housing,531115
+Lessors of nonresidential buildings (except mini- warehouses),531115
+Lessors of miniwarehouses and self-storage units,531135
+Lessors of other real estate property,531135
+Other real estate activities,531315
+Rental and leasing services and lessors of nonfinancial intangible assets (except copyrighted works),532
+"Professional, scientific, and technical services",54
+Management of companies (holding companies),55
+Administrative and support and waste management and remediation services,56
+Educational services,61
+Health care and social assistance,62
+"Arts, entertainment, and recreation",71
+Accommodation and food services,72
+Other services,81

--- a/btax/param_defaults/btax_defaults.json
+++ b/btax/param_defaults/btax_defaults.json
@@ -100,7 +100,7 @@
       "notes": "This parameter gives the rate of bonus depreciation on 15-year class property.  A rate of 100% results in full expensing.",
       "description": "Rate of bonus depreciation on 15-year class property",
       "value": [
-        50
+        50.0
       ],
       "min": [100.0],
       "max": [-100.0]

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -53,7 +53,8 @@ def translate_param_names(**user_mods):
 
 
     if user_mods['btax_betr_entity_Switch'] in (True, 'True'):
-        u_nc = user_mods['btax_betr_corp']
+        #u_nc = user_mods['btax_betr_corp']
+        u_nc = user_mods['btax_betr_pass']
     else:
         u_nc = user_mods['btax_betr_pass']
     user_params = {

--- a/btax/pull_soi_corp.py
+++ b/btax/pull_soi_corp.py
@@ -52,8 +52,6 @@ def load_corp_data():
         # drop total across all industries
         s_corp = s_corp.drop(s_corp[s_corp['INDY_CD']== 1.].index)
         # put in dollars (data in 1000s)
-        # for var in columns:
-        #     s_corp[var] = s_corp[var]*_CORP_FILE_FCTR
         s_corp[columns]=s_corp[columns]*_CORP_FILE_FCTR
     except IOError:
         print "IOError: S-Corp soi data file not found."
@@ -68,7 +66,7 @@ def load_corp_data():
         # put in dollars (data in 1000s)
         tot_corp[columns]=tot_corp[columns]*_CORP_FILE_FCTR
     except IOError:
-        print "IOError: S-Corp soi data file not found."
+        print "IOError: total corp soi data file not found."
         raise
 
     # read in crosswalk for bea and soi industry codes

--- a/btax/pull_soi_partner.py
+++ b/btax/pull_soi_partner.py
@@ -162,7 +162,7 @@ def load_partner_data(entity_dfs):
 
     ''' Attribute by partner type '''
 
-    # Read in data by partner type (gives allocation by partner type)
+    # Read in data by partner type (gives income allocation by partner type)
     df05 = format_excel(pd.read_excel(_TYP_FILE, skiprows=1, skip_footer=5))
     df05 = df05[['Item','All partners','Corporate general partners','Corporate limited partners',
         'Individual general partners','Individual limited partners','Partnership general partners',
@@ -241,11 +241,10 @@ def load_partner_data(entity_dfs):
     part_assets.drop(['Codes:','_merge'], axis=1, inplace=True)
 
     # allocate across partner type
-    part_assets['Fixed Assets_type'] = part_assets['Fixed Assets']*part_assets['inc_ratio']
-    part_assets['Inventories_type'] = part_assets['Inventories']*part_assets['inc_ratio']
-    part_assets['Land_type'] = part_assets['Land']*part_assets['inc_ratio']
-    part_assets['Depreciation_type'] = part_assets['Depreciation']*part_assets['inc_ratio']
-
+    part_assets['Fixed Assets'] = part_assets['Fixed Assets']*part_assets['inc_ratio']
+    part_assets['Inventories'] = part_assets['Inventories']*part_assets['inc_ratio']
+    part_assets['Land'] = part_assets['Land']*part_assets['inc_ratio']
+    part_assets['Depreciation'] = part_assets['Depreciation']*part_assets['inc_ratio']
 
     part_data = {'part_data': part_assets}
 

--- a/btax/pull_soi_partner.py
+++ b/btax/pull_soi_partner.py
@@ -155,13 +155,6 @@ def load_partner_data(entity_dfs):
     part_data.drop(['index','sector_code','major_code_x','minor_code',
                     'INDY_CD','major_code_y'],axis=1,inplace=True)
 
-    df05 = format_excel(pd.read_excel(_TYP_FILE, skiprows=1, skip_footer=5))
-    df05 = df05[['All partners','Corporate general partners','Corporate limited partners',
-    'Individual general partners','Individual limited partners','Partnership general partners',
-    'Partnership limited partners','Tax-exempt organization general partners',
-    'Tax-exempt organization limited partners','Nominee and other general partners',
-    'Nominee and other limited partners']]
-
     ### !!! Partner data has right industry breakouts, and ratio sum to 1 in ind,
     ## but totals not adding up to SOI controls. Not quite sure why. But within
     ## one percent of total except for fix assests off by 7%.  Going forward
@@ -171,109 +164,113 @@ def load_partner_data(entity_dfs):
     ''' Attribute by partner type '''
 
     # Read in data by partner type (gives allocation by partner type)
-    # df05 = pd.read_csv(_TYP_FILE_CSV).T
-    # typ_cross = pd.read_csv(_TYP_IN_CROSS_PATH)
-    # df05 = format_dataframe(df05, typ_cross)
-    # df05 = pd.melt(df05, id_vars=['Item', 'Codes:'], value_vars=['Corporate general partners',
-    #             'Corporate limited partners','Individual general partners',
-    #             'Individual limited partners','Partnership general partners',
-    #             'Partnership limited partners', 'Tax-exempt organization general partners',
-    #             'Tax-exempt organization limited partners','Nominee and other general partners',
-    #             'Nominee and other limited partners'],var_name='part_type',value_name='net_inc')
-    # print df05.head(n=5)
-    # quit()
-    #
-    # # update partner type names to something shorter
-    # # Not currnetly used except to count number of types
-    # part_types = {'Corporate general partners':'corp_gen',
-    #              'Corporate limited partners':'corp_lim',
-    #              'Individual general partners':'indv_gen',
-    #              'Individual limited partners':'indv_lim',
-    #              'Partnership general partners':'prt_gen',
-    #              'Partnership limited partners':'prt_lim',
-    #              'Tax-exempt organization general partners':'tax_gen',
-    #              'Tax-exempt organization limited partners':'tax_lim',
-    #              'Nominee and other general partners':'nom_gen',
-    #              'Nominee and other limited partners':'nom_lim'}
-    #
+    df05 = format_excel(pd.read_excel(_TYP_FILE, skiprows=1, skip_footer=5))
+    df05 = df05[['Item','All partners','Corporate general partners','Corporate limited partners',
+        'Individual general partners','Individual limited partners','Partnership general partners',
+        'Partnership limited partners','Tax-exempt organization general partners',
+        'Tax-exempt organization limited partners','Nominee and other general partners',
+        'Nominee and other limited partners']]
+    # # create dictionary with shorter part type names
+    part_types = {'Corporate general partners':'corp_gen',
+                  'Corporate limited partners':'corp_lim',
+                  'Individual general partners':'indv_gen',
+                  'Individual limited partners':'indv_lim',
+                  'Partnership general partners':'prt_gen',
+                  'Partnership limited partners':'prt_lim',
+                  'Tax-exempt organization general partners':'tax_gen',
+                  'Tax-exempt organization limited partners':'tax_lim',
+                  'Nominee and other general partners':'nom_gen',
+                  'Nominee and other limited partners':'nom_lim'}
+
+    # reshape data
+    df05 = pd.melt(df05, id_vars=['Item'], value_vars=['Corporate general partners',
+                 'Corporate limited partners','Individual general partners',
+                 'Individual limited partners','Partnership general partners',
+                 'Partnership limited partners', 'Tax-exempt organization general partners',
+                 'Tax-exempt organization limited partners','Nominee and other general partners',
+                 'Nominee and other limited partners'],var_name='part_type',value_name='net_inc')
+
+    # merge in codes
+    typ_cross = pd.read_csv(_TYP_IN_CROSS_PATH)
+    typ_cross['Industry:'] = typ_cross['Industry:'].str.strip()
+    df05['Item'] = df05['Item'].str.strip()
+    df05 = pd.merge(df05, typ_cross, how='inner', left_on=['Item'],
+        right_on=['Industry:'], left_index=False, right_index=False, sort=False,
+        copy=True, indicator=False)
+
     # # create sums by group
-    # grouped = pd.DataFrame({'sum' : df05.groupby(['Codes:']).apply(abs_sum, 'net_inc')}).reset_index()
+    grouped = pd.DataFrame({'sum' : df05.groupby(['Codes:']).apply(abs_sum, 'net_inc')}).reset_index()
     # # merge grouped data back to original df
     # # One could make this more efficient - one line of code - with appropriate
     # # pandas methods using groupby and apply above
-    # df05 = pd.merge(df05, grouped, how='left', left_on=['Codes:'],
-    #   right_on=['Codes:'], left_index=False, right_index=False, sort=False,
-    #   copy=True)
-    # df05['inc_ratio'] = (df05['net_inc'].astype(float).abs()/df05['sum'].replace({ 0 : np.nan })).replace({np.nan:0})
-    # df05 = df05[['Codes:','part_type','inc_ratio']]
-    #
+    df05 = pd.merge(df05, grouped, how='left', left_on=['Codes:'],
+        right_on=['Codes:'], left_index=False, right_index=False, sort=False,
+        copy=True)
+    df05['inc_ratio'] = (df05['net_inc'].astype(float).abs()/df05['sum'].replace({ 0 : np.nan })).replace({np.nan:0})
+    df05 = df05[['Codes:','part_type','net_inc','inc_ratio']]
+    print df05.to_csv('TestDF1.csv',encoding='utf-8')
+
+    # manufacturing is missing data for 2013, so use overall partnership splits
+    df05[df05['Codes:'] == 31]['inc_ratio'] = 
     # # add other sector codes for manufacturing
-    # manu = df05[df05['Codes:'] == 31]
-    # df_manu = (manu.append(manu)).reset_index()
-    # df_manu.loc[:len(part_types), 'Codes:'] = 32
-    # df_manu.loc[len(part_types):, 'Codes:'] = 33
-    # df05 = df05.append(df_manu,ignore_index=True).reset_index().copy()
+
+    manu = df05[df05['Codes:'] == 31]
+    df_manu = (manu.append(manu)).reset_index(drop=True)
+    df_manu.loc[:len(part_types), 'Codes:'] = 32
+    df_manu.loc[len(part_types):, 'Codes:'] = 33
+    df05 = df05.append(df_manu,ignore_index=True).reset_index(drop=True).copy()
+    print df05.to_csv('TestDF.csv',encoding='utf-8')
+    quit()
     #
     # # load crosswalk for soi and bea industry codes
-    # soi_bea_ind_codes = pd.read_csv(_SOI_BEA_CROSS, dtype={'bea_ind_code':str})
-    # soi_bea_ind_codes.drop('notes', axis=1, inplace=True)
+    soi_bea_ind_codes = pd.read_csv(_SOI_BEA_CROSS, dtype={'bea_ind_code':str})
+    soi_bea_ind_codes.drop('notes', axis=1, inplace=True)
     #
     # # Merge SOI codes to BEA data
-    # df05 = pd.merge(soi_bea_ind_codes, df05, how='inner', left_on=['sector_code'],
-    #   right_on=['Codes:'], left_index=False, right_index=False, sort=False,
-    #   copy=True,indicator=True)
-    # df05 = df05[df05['_merge']=='both']
-    # df05.drop(['index','_merge','level_0','Codes:'], axis=1, inplace=True)
-    #
+    df05 = pd.merge(soi_bea_ind_codes, df05, how='inner', left_on=['sector_code'],
+        right_on=['Codes:'], left_index=False, right_index=False, sort=False,
+        copy=True,indicator=True)
+    df05 = df05[df05['_merge']=='both']
+    df05.drop(['_merge','Codes:'], axis=1, inplace=True)
+
     # # merge partner type ratios with partner asset data
     # # likely better way to do this...
-    # df03_sector = df03[(df03['Codes:']>9) & (df03['Codes:']<100)]
-    # df03_major = df03[(df03['Codes:']>99) & (df03['Codes:']<1000)]
-    # df03_minor = df03[(df03['Codes:']>99999) & (df03['Codes:']<1000000)]
-    # sector_df = pd.merge(df03_sector, df05, how='inner', left_on=['Codes:'],
-    #   right_on=['sector_code'], left_index=False, right_index=False, sort=False,
-    #   copy=True,indicator=True)
-    # major_df = pd.merge(df03_major, df05, how='inner', left_on=['Codes:'],
-    #   right_on=['major_code'], left_index=False, right_index=False, sort=False,
-    #   copy=True,indicator=True)
-    # minor_df = pd.merge(df03_minor, df05, how='inner', left_on=['Codes:'],
-    #   right_on=['minor_code'], left_index=False, right_index=False, sort=False,
-    #   copy=True,indicator=True)
+    df03_sector = df03[(df03['INDY_CD']>9) & (df03['INDY_CD']<100)]
+    df03_major = df03[(df03['INDY_CD']>99) & (df03['INDY_CD']<1000)]
+    df03_minor = df03[(df03['INDY_CD']>99999) & (df03['INDY_CD']<1000000)]
+    sector_df = pd.merge(df03_sector, df05, how='inner', left_on=['INDY_CD'],
+        right_on=['sector_code'], left_index=False, right_index=False, sort=False,
+        copy=True,indicator=True)
+    major_df = pd.merge(df03_major, df05, how='inner', left_on=['INDY_CD'],
+        right_on=['major_code'], left_index=False, right_index=False, sort=False,
+        copy=True,indicator=True)
+    minor_df = pd.merge(df03_minor, df05, how='inner', left_on=['INDY_CD'],
+        right_on=['minor_code'], left_index=False, right_index=False, sort=False,
+        copy=True,indicator=True)
+
+    part_assets = sector_df.append([major_df,minor_df],ignore_index=True).copy().reset_index(drop=True)
+    part_assets.drop(['_merge'], axis=1, inplace=True)
     #
-    # part_assets = sector_df.append([major_df,minor_df],ignore_index=True).copy().reset_index()
-    # part_assets.drop(['index','_merge'], axis=1, inplace=True)
-    #
-    # part_assets['Fixed Assets_type'] = part_assets['Fixed Assets']*part_assets['inc_ratio']
-    # part_assets['Inventories_type'] = part_assets['Inventories']*part_assets['inc_ratio']
-    # part_assets['Land_type'] = part_assets['Land']*part_assets['inc_ratio']
-    #
+    part_assets['Fixed Assets_type'] = part_assets['Fixed Assets']*part_assets['inc_ratio']
+    part_assets['Inventories_type'] = part_assets['Inventories']*part_assets['inc_ratio']
+    part_assets['Land_type'] = part_assets['Land']*part_assets['inc_ratio']
     # # drop repeats at level of industry codes- this best partner data can be identified at
-    # part_assets.drop_duplicates(subset=['Codes:','part_type'],inplace=True)
+    part_assets.drop_duplicates(subset=['INDY_CD','part_type'],inplace=True)
     #
     # # sum at industry-partner type level
-    # part_data = pd.DataFrame({'Fixed Assets' :
-    #                           part_assets.groupby(['Codes:'])['Fixed Assets_type'].sum()}).reset_index()
-    # part_data['Inventories'] = pd.DataFrame({'Inventories' :
-    #                           part_assets.groupby(['Codes:'])['Inventories_type'].sum()}).reset_index()['Inventories']
-    # part_data['Land'] = pd.DataFrame({'Land' :
-    #                           part_assets.groupby(['Codes:'])['Land_type'].sum()}).reset_index()['Land']
-    # part_data['inc_ratio'] = pd.DataFrame({'inc_ratio' :
-    #                           part_assets.groupby(['Codes:'])['inc_ratio'].sum()}).reset_index()['inc_ratio']
+    part_data = pd.DataFrame({'Fixed Assets' :
+        part_assets.groupby(['INDY_CD'])['Fixed Assets_type'].sum()}).reset_index()
+    part_data['Inventories'] = pd.DataFrame({'Inventories' :
+        part_assets.groupby(['INDY_CD'])['Inventories_type'].sum()}).reset_index()['Inventories']
+    part_data['Land'] = pd.DataFrame({'Land' :
+        part_assets.groupby(['INDY_CD'])['Land_type'].sum()}).reset_index()['Land']
+    part_data['inc_ratio'] = pd.DataFrame({'inc_ratio' :
+        part_assets.groupby(['INDY_CD'])['inc_ratio'].sum()}).reset_index()['inc_ratio']
+
+    data = {'part_data':part_data}
     #
-    # data = {'part_data':part_data}
-    #
-    # part_data.to_csv('TestDF2.csv',encoding='utf-8')
-    # quit()
-    #  # merge codes to corp data
-    # all_corp = pd.merge(all_corp, soi_ind_codes, how='inner', left_on=['INDY_CD'], right_on=['minor_code_alt'],
-    #   left_index=False, right_index=False, sort=False,
-    #   suffixes=('_x', '_y'), copy=True, indicator=True)
-    # # keep only rows that match in both datasets - this should keep only unique soi minor industries
-    # all_corp = all_corp.drop(all_corp[all_corp['_merge']!='both' ].index)
-    #
-    # corp_ratios = all_corp[['INDY_CD','minor_code_alt','minor_code','major_code','sector_code']]
-    # for var in corp_data_variables_of_interest :
-    #     corp_ratios[var+'_ratio'] = all_corp.groupby(['sector_code'])[var].apply(lambda x: x/float(x.sum()))
+    part_data.to_csv('TestDF2.csv',encoding='utf-8')
+    quit()
 
     part_data = {'part_data': part_data}
 

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -88,8 +88,8 @@ def fixed_assets(soi_data):
 
     # Merge SOI data to BEA data
     bea_FA = bea_FA[['assets','bea_asset_code','bea_ind_code','Asset Type', 'minor_code_alt']].copy()
-    soi_data = soi_data[['minor_code_alt','Fixed Assets','Land','entity_type','tax_treat']].copy()
-    bea_FA= pd.merge(bea_FA, soi_data, how='inner', left_on=['minor_code_alt'],
+    soi_data = soi_data[['minor_code_alt','Fixed Assets','Land','entity_type','tax_treat','part_type']].copy()
+    bea_FA= pd.merge(bea_FA, soi_data, how='right', left_on=['minor_code_alt'],
       right_on=['minor_code_alt'], left_index=False, right_index=False, sort=False,
       copy=True,indicator=False)
 
@@ -195,7 +195,7 @@ def land(soi_data, bea_FA):
 
     bea_land['land_ratio'] = bea_land.groupby(['BEA Corp'])['Land'].apply(lambda x: x/float(x.sum()))
     bea_land['BEA Land'] = bea_land['land_ratio']*bea_land['BEA Land']
-    bea_land = bea_land[['BEA Land','entity_type','tax_treat','bea_code','minor_code_alt']].copy()
+    bea_land = bea_land[['BEA Land','entity_type','tax_treat','bea_code','minor_code_alt','part_type']].copy()
 
     # total land attributed above matches Fin Accts totals for non-owner occ housing
 
@@ -217,9 +217,9 @@ def land(soi_data, bea_FA):
     bea_res_assets['Asset Type'] = 'Residential'
     bea_res_assets['bea_asset_code'] = 'RES'
     bea_res_assets = bea_res_assets[['Asset Type','bea_asset_code','bea_ind_code',
-                                     'minor_code_alt','entity_type','tax_treat',
+                                     'minor_code_alt','entity_type','tax_treat','part_type',
                                      'assets']].copy()
-    bea_res_assets.drop_duplicates(['assets','entity_type'], keep='last',inplace=True)
+    bea_res_assets.drop_duplicates(['assets','entity_type','part_type'], keep='last',inplace=True)
 
 
     return bea_land, bea_res_assets, owner_occ_dict
@@ -234,14 +234,15 @@ def combine(fixed_assets,inventories,land,res_assets,owner_occ_dict):
         :rtype: dictionary
     """
     fixed_assets = fixed_assets[['assets', 'bea_asset_code', 'bea_ind_code',
-                                 'Asset Type','minor_code_alt','entity_type','tax_treat']].copy()
+                                 'Asset Type','minor_code_alt','entity_type',
+                                 'part_type','tax_treat']].copy()
     inventories = inventories[['BEA Inventories','minor_code_alt','entity_type',
-                               'tax_treat','bea_code']].copy()
+                               'part_type','tax_treat','bea_code']].copy()
     inventories.rename(columns={"BEA Inventories":"assets",
                                 "bea_code":"bea_ind_code"},inplace=True)
     inventories['Asset Type'] = 'Inventories'
     inventories['bea_asset_code'] = 'INV'
-    land = land[['BEA Land', 'entity_type', 'tax_treat', 'bea_code', 'minor_code_alt']].copy()
+    land = land[['BEA Land', 'entity_type', 'part_type','tax_treat', 'bea_code', 'minor_code_alt']].copy()
     land.rename(columns={"BEA Land":"assets",
                          "bea_code":"bea_ind_code"},inplace=True)
     land['Asset Type'] = 'Land'

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -199,7 +199,7 @@ def land(soi_data, bea_FA):
 
     # total land attributed above matches Fin Accts totals for non-owner occ housing
 
-    # attribute residential fixed assets across tax treatment (they all got to
+    # attribute residential fixed assets across tax treatment (they all go to
     # one specific production sector)
     # attribute residential structures across entity types in proportion to land
     bea_res_assets = bea_FA[bea_FA['minor_code_alt']==531115].copy()

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -52,7 +52,7 @@ def run_btax(test_run,baseline=False,start_year=2016,iit_reform=None,**user_para
 	:returns: METR (by industry and asset) and METTR (by asset)
 	:rtype: DataFrame
     """
-    calc_assets = False
+    calc_assets = True
 
     iit_reform = iit_reform or {}
     if calc_assets or not os.path.exists(ASSET_PRE_CACHE_FILE):

--- a/btax/soi_processing.py
+++ b/btax/soi_processing.py
@@ -40,7 +40,7 @@ def pull_soi_data():
     c_corp.loc[:,'entity_type'] = 'c_corp'
     s_corp = entity_dfs['s_corp'][['minor_code_alt','Land','Fixed Assets','Inventories']].copy()
     s_corp.loc[:,'entity_type'] = 's_corp'
-    partner = entity_dfs['part_data'][['minor_code_alt','Land','Fixed Assets','Inventories']].copy()
+    partner = entity_dfs['part_data'][['minor_code_alt','Land','Fixed Assets','Inventories','part_type']].copy()
     partner.loc[:,'entity_type'] = 'partnership'
     sole_prop = entity_dfs['sole_prop_data'][['minor_code_alt','Land','Fixed Assets','Inventories']].copy()
     sole_prop.loc[:,'entity_type'] = 'sole_prop'
@@ -58,7 +58,9 @@ def pull_soi_data():
 
     soi_data['tax_treat'] = 'non-corporate'
     soi_data.ix[soi_data['entity_type']=='c_corp', 'tax_treat'] = 'corporate'
-    soi_data = pd.merge(soi_data, soi_bea_ind_codes, how='inner', left_on=['minor_code_alt'],
+    soi_data.ix[(soi_data['entity_type']=='partnership') & (soi_data['part_type']=='Corporate general partners'), 'tax_treat'] = 'corporate'
+    soi_data.ix[(soi_data['entity_type']=='partnership') & (soi_data['part_type']=='Corporate limited partners'), 'tax_treat'] = 'corporate'
+    soi_data = pd.merge(soi_data, soi_bea_ind_codes, how='left', left_on=['minor_code_alt'],
       right_on=['minor_code_alt'], left_index=False, right_index=False, sort=False,
       copy=True)
 

--- a/btax/util.py
+++ b/btax/util.py
@@ -77,6 +77,7 @@ def get_paths():
     paths['_INC_FILE'] = _INC_FILE = os.path.join(_PRT_DIR, '13pa01.xls')
     paths['_AST_FILE'] = _AST_FILE = os.path.join(_PRT_DIR, '13pa03.xls')
     #paths['_AST_profit_FILE'] = _AST_profit_FILE = os.path.join(_PRT_DIR, '12pa03_profit.xlsx')
+    paths['_TYP_IN_CROSS_PATH'] = _TYP_IN_CROSS_PATH = os.path.join(_PRT_DIR, '13pa05_Crosswalk.csv')
     paths['_TYP_FILE'] = _TYP_FILE = os.path.join(_PRT_DIR, '13pa05.xls')
     paths['_PROP_DIR'] = _PROP_DIR = os.path.join(_SOI_DIR, 'soi_proprietorship')
     paths['_PRT_DIR'] = _PRT_DIR = os.path.join(_SOI_DIR, 'soi_partner')


### PR DESCRIPTION
This PR splits partner assets between corporate and non-corporate partners.

It also adds a script to help check:
1) That asset totals match BEA totals
2) That assets are distributed between corporate and non-corporate entities in a reasonable way.