### PR TITLE
Update cost of capital calculation for inventories

### DIFF
--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -39,6 +39,8 @@ def asset_calcs(params,asset_data):
     inv_credit = params['inv_credit']
     w = params['prop tax']
     z = params['depr allow']
+    Y_v = params['Y_v']
+    phi = params['phi']
     financing_list = params['financing_list']
     entity_list = params['entity_list']
     asset_dict = params['asset_dict']
@@ -54,6 +56,9 @@ def asset_calcs(params,asset_data):
                 output_by_asset['delta']) * (1- inv_credit- (stat_tax[j] *
                 output_by_asset['z'+entity_list[j]+financing_list[i]])) /
                 (1-stat_tax[j])) + w - output_by_asset['delta'])
+            output_by_asset.loc[output_by_asset['Asset Type']=="Inventories",'rho'+entity_list[j]+financing_list[i]] = \
+                    ((phi*(((1/Y_v)*np.log((np.exp(discount_rate[i,j]*Y_v)-stat_tax[j])/(1-stat_tax[j])))-inflation_rate))
+                    + ((1-phi)*(((1/Y_v)*np.log((np.exp((discount_rate[i,j]-inflation_rate)*Y_v)-stat_tax[j])/(1-stat_tax[j]))))))
             output_by_asset['metr'+entity_list[j]+financing_list[i]] = \
                 (output_by_asset['rho'+entity_list[j]+financing_list[i]] -
                 (r_prime[i,j] - inflation_rate))/ output_by_asset['rho'+entity_list[j]+financing_list[i]]

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -117,6 +117,7 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
     int_haircut = user_params['int_haircut']
     bonus_deprec = user_params['bonus_deprec']
     deprec_system = user_params['deprec_system']
+    phi = 0.5 # fraction of inventories using LIFO accounting
     # we don't have IP class in user params, so put here
     bonus_deprec['50'] = 0.
     deprec_system['50'] = 'ADS'
@@ -172,12 +173,15 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
         u_nc = user_params['u_nc']
     u_array = np.array([u_c, u_nc])
 
-    # Parameters for holding periods of assets, etc.
+    # Parameters for holding periods of assets
     Y_td = 8.
     Y_scg = 4/12.
     Y_lcg = 8.
+    Y_v = 4/12. # holding period for inventories
     gamma = 0.3
-    m = 0.44
+
+    # Miscellaneous parameters
+    m = 0.44 # Divident payout rate
 
     #intermediate variables
     sprime_c_td = (1/Y_td)*np.log(((1-tau_td)*np.exp(i*Y_td))+tau_td)-pi
@@ -369,6 +373,8 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
         'financing_list':financing_list,
         'entity_list':entity_list,
         'delta': delta,
+        'Y_v':Y_v,
+        'phi':phi,
         'asset_dict': asset_dict,
         'ind_dict': ind_dict
     }


### PR DESCRIPTION
This PR fixes the calculation for the cost of capital for inventory investment.  Inventories are handled differently than depreciable assets and so the cost of capital calculation is made separately for these assets.

