### PR TITLE
Add major groups

### DIFF
--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """
 Calculate Rho, METR, & METTR (calc_final_output.py):
 -------------------------------------------------------------------------------
@@ -131,7 +134,7 @@ def asset_calcs(params,asset_data):
     by_major_asset['Asset'] = by_major_asset['major_asset_group']
     by_major_asset['Asset Type'] = by_major_asset['major_asset_group']
 
-    # make calculation for over all rates - this will be appened to both the by asset and by industry output
+    # make calculation for overall rates
     corp_list = ['z_c','z_c_d','z_c_e','rho_c','rho_c_d','rho_c_e']
     noncorp_list = ['z_nc','z_nc_d','z_nc_e','rho_nc','rho_nc_d','rho_nc_e']
     overall = pd.DataFrame({'delta' : ((output_by_asset['delta']*
@@ -163,7 +166,7 @@ def asset_calcs(params,asset_data):
     by_major_asset = by_major_asset[by_major_asset['major_asset_group']!='Inventories'].copy()
     by_major_asset = by_major_asset[by_major_asset['major_asset_group']!='Land'].copy()
     output_by_asset = (output_by_asset.append([by_major_asset,overall])).copy().reset_index()
-
+    output_by_asset.to_csv('output_by_asset.csv',encoding='utf-8')
     return output_by_asset
 
 
@@ -224,7 +227,6 @@ def industry_calcs(params, asset_data, output_by_asset):
     by_industry_tax['assets'] = (pd.DataFrame({'assets' : by_industry_asset.groupby(
         ['bea_ind_code','tax_treat'])['assets'].sum()})).reset_index()['assets']
 
-
     # calculate the cost of capital, metr, mettr
     for i in range(save_rate.shape[0]):
         for j in range(save_rate.shape[1]):
@@ -254,15 +256,100 @@ def industry_calcs(params, asset_data, output_by_asset):
       right_on=['bea_ind_code'], left_index=False, right_index=False, sort=False,
       copy=True)
     by_industry['Industry'] = by_industry['Industry'].str.strip()
-
-    # create major industry variable
+    by_industry['Industry'] = by_industry['Industry'].str.replace(u"Â ", u"")
     by_industry['major_industry'] = by_industry['Industry']
     by_industry['major_industry'].replace(ind_dict,inplace=True)
 
-    # make computations by major industry
-    # append by major to by industry
-    # append overall rate to this output_by_industry
+    '''
+    ### Do above for major industry groups
+    '''
+    # create major industry variable
+    by_industry_asset['Industry'] = by_industry_asset['Industry'].str.strip()
+    by_industry_asset['Industry'] = by_industry_asset['Industry'].str.replace('Â ', '')
+    by_industry_asset['major_industry'] = by_industry_asset['Industry']
+    by_industry_asset['major_industry'].replace(ind_dict,inplace=True)
 
+    # create weighted averages by industry/tax treatment
+    by_major_ind_tax = pd.DataFrame({'delta' : by_industry_asset.groupby(
+        ['major_industry','tax_treat'] ).apply(wavg, "delta", "assets")}).reset_index()
+    col_list = ['z_c','z_c_d','z_c_e','z_nc', 'z_nc_d',
+                        'z_nc_e', 'rho_c','rho_c_d','rho_c_e','rho_nc',
+                        'rho_nc_d', 'rho_nc_e']
+    for item in col_list:
+        by_major_ind_tax[item] = (pd.DataFrame({item : by_industry_asset.groupby(
+            ['major_industry','tax_treat']).apply(wavg, item, "assets")})).reset_index()[item]
+
+    by_major_ind_tax['assets'] = (pd.DataFrame({'assets' : by_industry_asset.groupby(
+        ['major_industry','tax_treat'])['assets'].sum()})).reset_index()['assets']
+
+    # calculate the cost of capital, metr, mettr
+    for i in range(save_rate.shape[0]):
+        for j in range(save_rate.shape[1]):
+            by_major_ind_tax['metr'+entity_list[j]+financing_list[i]] = \
+                ((by_major_ind_tax['rho'+entity_list[j]+financing_list[i]] -
+                (r_prime[i,j] - inflation_rate))/(by_major_ind_tax['rho'+entity_list[j]+financing_list[i]]))
+            by_major_ind_tax['mettr'+entity_list[j]+financing_list[i]] = \
+                ((by_major_ind_tax['rho'+entity_list[j]+financing_list[i]] -
+                save_rate[i,j])/(by_major_ind_tax['rho'+entity_list[j]+financing_list[i]]))
+
+    # put together in different format (later we should consider changing how
+    # output is handled and do long format)
+    corp = by_major_ind_tax[by_major_ind_tax['tax_treat']=='corporate'].copy()
+    non_corp = by_major_ind_tax[by_major_ind_tax['tax_treat']=='non-corporate'].copy()
+    corp = corp[['major_industry','delta','z_c','z_c_d','z_c_e','rho_c','rho_c_d','rho_c_e',
+                 'metr_c','metr_c_d','metr_c_e','mettr_c','mettr_c_d','mettr_c_e','assets']].copy()
+    non_corp = non_corp[['major_industry','delta','z_nc','z_nc_d','z_nc_e','rho_nc','rho_nc_d','rho_nc_e',
+                 'metr_nc','metr_nc_d','metr_nc_e','mettr_nc','mettr_nc_d','mettr_nc_e','assets']].copy()
+    corp.rename(columns={"delta": "delta_c","assets": "assets_c"},inplace=True)
+    non_corp.rename(columns={"delta": "delta_nc","assets": "assets_nc"},inplace=True)
+    by_major_ind = pd.merge(corp, non_corp, how='inner', on=['major_industry'],
+                           left_index=False, right_index=False, sort=False,copy=True)
+    by_major_ind['Industry'] = by_major_ind['major_industry']
+
+    # make calculation for overall rates
+    # keep only equip and structures when doing ind calculations
+    output_by_asset = output_by_asset[output_by_asset['asset_category']!='Intellectual Property'].copy()
+    output_by_asset = output_by_asset[output_by_asset['asset_category']!='Land'].copy()
+    output_by_asset = output_by_asset[output_by_asset['asset_category']!='Inventories'].copy()
+    corp_list = ['z_c','z_c_d','z_c_e','rho_c','rho_c_d','rho_c_e']
+    noncorp_list = ['z_nc','z_nc_d','z_nc_e','rho_nc','rho_nc_d','rho_nc_e']
+    overall = pd.DataFrame({'delta_c' : ((output_by_asset['delta']*
+              output_by_asset['assets_c']).sum()/output_by_asset['assets_c'].sum())},index=[0])
+    overall['delta_nc'] = ((output_by_asset['delta']*
+              output_by_asset['assets_nc']).sum()/output_by_asset['assets_nc'].sum())
+    overall['assets_c'] = output_by_asset['assets_c'].sum()
+    overall['assets_nc'] = output_by_asset['assets_nc'].sum()
+    # overall = pd.DataFrame({'delta_nc' : ((output_by_asset['delta']*
+    #           output_by_asset['assets_nc']).sum()/output_by_asset['assets_nc'].sum())}).reset_index()
+    overall['Industry'] = 'All Investments'
+    overall['major_industry'] = 'All Investments'
+    for item in corp_list:
+        overall[item] = ((output_by_asset[item]*output_by_asset['assets_c']).sum()/
+                         output_by_asset['assets_c'].sum())
+    for item in noncorp_list:
+        overall[item] = ((output_by_asset[item]*output_by_asset['assets_nc']).sum()/
+                         output_by_asset['assets_nc'].sum())
+    for i in range(save_rate.shape[0]):
+        for j in range(save_rate.shape[1]):
+            overall['metr'+entity_list[j]+financing_list[i]] = \
+                ((overall['rho'+entity_list[j]+financing_list[i]] -
+                (r_prime[i,j] - inflation_rate))/(overall['rho'+entity_list[j]+financing_list[i]]))
+            overall['mettr'+entity_list[j]+financing_list[i]] = \
+                ((overall['rho'+entity_list[j]+financing_list[i]] -
+                save_rate[i,j])/(overall['rho'+entity_list[j]+financing_list[i]]))
+
+    # append by_major_asset to output_by_asset
+    # drop major inds when only one in major group
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Utilities'].copy()
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Construction'].copy()
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Wholesale trade'].copy()
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Retail trade'].copy()
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Management of companies and enterprises'].copy()
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Educational services'].copy()
+    by_major_ind = by_major_ind[by_major_ind['major_industry']!='Other services, except government'].copy()
+    by_industry = (by_industry.append([by_major_ind,overall])).copy().reset_index()
+
+    by_industry.to_csv('by_ind_test.csv',encoding='utf-8')
     return by_industry
 
 def wavg(group, avg_name, weight_name):

--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """
 Calculate Rho, METR, & METTR (calc_final_output.py):
 -------------------------------------------------------------------------------
@@ -165,8 +162,9 @@ def asset_calcs(params,asset_data):
     # drop asset types that are only one in major group
     by_major_asset = by_major_asset[by_major_asset['major_asset_group']!='Inventories'].copy()
     by_major_asset = by_major_asset[by_major_asset['major_asset_group']!='Land'].copy()
-    output_by_asset = (output_by_asset.append([by_major_asset,overall])).copy().reset_index()
-    output_by_asset.to_csv('output_by_asset.csv',encoding='utf-8')
+    output_by_asset = (output_by_asset.append([by_major_asset,overall],ignore_index=True)).copy().reset_index()
+    output_by_asset.drop('index', axis=1,inplace=True)
+
     return output_by_asset
 
 
@@ -195,6 +193,7 @@ def industry_calcs(params, asset_data, output_by_asset):
     financing_list = params['financing_list']
     entity_list = params['entity_list']
     ind_dict = params['ind_dict']
+    bea_code_dict = params['bea_code_dict']
 
     # initialize dataframe - start w/ fixed assets by industry and asset type
     bea = asset_data.copy()
@@ -256,18 +255,16 @@ def industry_calcs(params, asset_data, output_by_asset):
       right_on=['bea_ind_code'], left_index=False, right_index=False, sort=False,
       copy=True)
     by_industry['Industry'] = by_industry['Industry'].str.strip()
-    by_industry['Industry'] = by_industry['Industry'].str.replace(u"Â ", u"")
-    by_industry['major_industry'] = by_industry['Industry']
-    by_industry['major_industry'].replace(ind_dict,inplace=True)
+    by_industry['major_industry'] = by_industry['bea_ind_code']
+    by_industry['major_industry'].replace(bea_code_dict,inplace=True)
 
     '''
     ### Do above for major industry groups
     '''
     # create major industry variable
     by_industry_asset['Industry'] = by_industry_asset['Industry'].str.strip()
-    by_industry_asset['Industry'] = by_industry_asset['Industry'].str.replace('Â ', '')
-    by_industry_asset['major_industry'] = by_industry_asset['Industry']
-    by_industry_asset['major_industry'].replace(ind_dict,inplace=True)
+    by_industry_asset['major_industry'] = by_industry_asset['bea_ind_code']
+    by_industry_asset['major_industry'].replace(bea_code_dict,inplace=True)
 
     # create weighted averages by industry/tax treatment
     by_major_ind_tax = pd.DataFrame({'delta' : by_industry_asset.groupby(
@@ -347,9 +344,9 @@ def industry_calcs(params, asset_data, output_by_asset):
     by_major_ind = by_major_ind[by_major_ind['major_industry']!='Management of companies and enterprises'].copy()
     by_major_ind = by_major_ind[by_major_ind['major_industry']!='Educational services'].copy()
     by_major_ind = by_major_ind[by_major_ind['major_industry']!='Other services, except government'].copy()
-    by_industry = (by_industry.append([by_major_ind,overall])).copy().reset_index()
+    by_industry = (by_industry.append([by_major_ind,overall],ignore_index=True)).copy().reset_index()
+    by_industry.drop('index', axis=1,inplace=True)
 
-    by_industry.to_csv('by_ind_test.csv',encoding='utf-8')
     return by_industry
 
 def wavg(group, avg_name, weight_name):

--- a/btax/param_defaults/btax_results_by_asset.json
+++ b/btax/param_defaults/btax_results_by_asset.json
@@ -14,11 +14,7 @@
         "col_label": "METR, corporate typically-financed investment",
         "name": "metr_c",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate
-        investment financed by an historical mix of debt and equity.  The
-        debt-equity mix varies between corporate and non-corporate entities,
-        but is the same across industry and asset.  The METR includes
-        only the impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate investment financed by an historical mix of debt and equity.  The debt-equity mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -29,11 +25,7 @@
         "col_label": "METR, non-corporate typically-financed investment",
         "name": "metr_nc",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate
-        investment financed by an historical mix of debt and equity.  The
-        debt-equity mix varies between corporate and non-corporate entities,
-        but is the same across industry and asset.  The METR includes only the
-        impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate investment financed by an historical mix of debt and equity.  The debt-equity mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -44,9 +36,7 @@
         "col_label": "METR, corporate equity-financed investment",
         "name": "metr_c_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate
-        equity-financed investment.  The METR includes only the impact of the
-        first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate equity-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -57,9 +47,7 @@
         "col_label": "METR, non-corporate equity-financed investment",
         "name": "metr_nc_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate
-        equity-financed investment.  The METR includes only the impact of the
-        first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate equity-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -70,9 +58,7 @@
         "col_label": "METR, corporate debt-financed investment",
         "name": "metr_c_d",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate
-        debt-financed investment.  The METR includes only the impact of the
-        first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate debt-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -83,9 +69,7 @@
          "col_label": "METR, non-corporate debt-financed investment",
          "name": "metr_nc_d",
          "table_id": "metr",
-         "tooltip": "Marginal effective tax rate on new investments, non-corporate
-         debts-financed investment.  The METR includes only the impact of the
-         first level of taxation on the incentives to invest.",
+         "tooltip": "Marginal effective tax rate on new investments, non-corporate debts-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -96,12 +80,7 @@
          "col_label": "METTR, corporate typically-financed investment",
          "name": "mettr_c",
          "table_id": "mettr",
-         "tooltip": "Marginal effective total tax rate on new investments,
-         corporate investment financed by an historical mix of debt and equity.
-         This mix varies between corporate and non-corporate entities, but is
-         the same across industry and asset.  The METTR includes the impact of
-         all levels of taxation (both on business entities and savers) on the
-         incentives to invest.",
+         "tooltip": "Marginal effective total tax rate on new investments, corporate investment financed by an historical mix of debt and equity. This mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -112,12 +91,7 @@
         "col_label": "METTR, non-corporate typically-financed investment",
         "name": "mettr_nc",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        non-corporate investment financed by an historical mix of debt and equity.
-        This mix varies between corporate and non-corporate entities, but is
-        the same across industry and asset.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, non-corporate investment financed by an historical mix of debt and equity. This mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -128,10 +102,7 @@
         "col_label": "METTR, corporate equity-financed investment",
         "name": "mettr_c_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        corporate equity-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, corporate equity-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -142,10 +113,7 @@
         "col_label": "METTR, non-corporate equity-financed investment",
         "name": "mettr_nc_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        non-corporate equity-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, non-corporate equity-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -156,10 +124,7 @@
         "col_label": "METTR, corporate debt-financed investment",
         "name": "mettr_c_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        corporate debt-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, corporate debt-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -170,10 +135,8 @@
         "col_label": "METTR, non-corporate debt-financed investment",
         "name": "mettr_nc_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        non-corporate debt-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.","divisor": 1,
+        "tooltip": "Marginal effective total tax rate on new investments, non-corporate debt-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "divisor": 1,
         "decimals": 3
       }
     ],
@@ -183,11 +146,7 @@
         "col_label": "Cost of capital, typically-financed corporate investment",
         "name": "rho_c",
         "table_id": "coc",
-        "tooltip": "Cost of capital, corporate investment financed with an
-        historical mix of debt and equity.  This mix varies between corporate
-        and non-corporate entities, but is the same across industry and asset.
-        The cost of capital is calculated as the net-of-depreciation, before-tax
-        rate of return.",
+        "tooltip": "Cost of capital, corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset. The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -198,11 +157,7 @@
           "col_label": "Cost of capital, typically-financed non-corporate investment",
           "name": "rho_nc",
           "table_id": "coc",
-          "tooltip": "Cost of capital, non-corporate investment financed with an
-          historical mix of debt and equity.  This mix varies between corporate
-          and non-corporate entities, but is the same across industry and asset.
-          The cost of capital is calculated as the net-of-depreciation, before-tax
-          rate of return.",
+          "tooltip": "Cost of capital, non-corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset. The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
           "divisor": 1,
           "decimals": 3
         }
@@ -213,8 +168,7 @@
         "col_label": "Cost of capital, equity-financed corporate investment",
         "name": "rho_c_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, equity-financed corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -225,8 +179,7 @@
         "col_label": "Cost of capital, equity-financed non-corporate investment",
         "name": "rho_nc_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, equity-financed non-corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed non-corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -237,8 +190,7 @@
         "col_label": "Cost of capital, debt-financed corporate investment",
         "name": "rho_c_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, debt-financed corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -249,8 +201,7 @@
         "col_label": "Cost of capital, debt-financed non-corporate investment",
         "name": "rho_nc_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, debt-financed non-corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed non-corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -261,10 +212,7 @@
         "col_label": "NPV of depreciation deductions, typically financed corporate investment",
         "name": "z_c",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, corporate
-        investment financed with an historical mix of debt and equity.  This mix
-        varies between corporate and non-corporate entities, but is the same across
-        industry and asset.",
+        "tooltip": "Net present value of depreciation deductions, corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset.",
         "divisor": 1,
         "decimals": 3
       }
@@ -275,10 +223,7 @@
           "col_label": "NPV of depreciation deductions, typically financed non-corporate investment",
           "name": "z_nc",
           "table_id": "d",
-          "tooltip": "Net present value of depreciation deductions, non-corporate
-          investment financed with an historical mix of debt and equity.  This mix
-          varies between corporate and non-corporate entities, but is the same across
-          industry and asset.",
+          "tooltip": "Net present value of depreciation deductions, non-corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset.",
           "divisor": 1,
           "decimals": 3
         }
@@ -289,8 +234,7 @@
         "col_label": "NPV of depreciation deductions, equity-financed corporate investment",
         "name": "z_c_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, equity-financed
-        corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, equity-financed corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -301,8 +245,7 @@
         "col_label": "NPV of depreciation deductions, equity-financed non-corporate investment",
         "name": "z_nc_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, equity-financed
-        non-corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, equity-financed non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -313,8 +256,7 @@
         "col_label": "NPV of depreciation deductions, debt-financed corporate investment",
         "name": "z_c_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, debt-financed
-        corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, debt-financed corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -325,8 +267,7 @@
         "col_label": "NPV of depreciation deductions, debt-financed non-corporate investment",
         "name": "z_nc_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, debt-financed
-        non-corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, debt-financed non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }

--- a/btax/param_defaults/btax_results_by_asset.json
+++ b/btax/param_defaults/btax_results_by_asset.json
@@ -11,10 +11,14 @@
     [
       "metr_c",
       {
-        "col_label": "METR, corporate typically financed investment",
+        "col_label": "METR, corporate typically-financed investment",
         "name": "metr_c",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate
+        investment financed by an historical mix of debt and equity.  The
+        debt-equity mix varies between corporate and non-corporate entities,
+        but is the same across industry and asset.  The METR includes
+        only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -22,10 +26,14 @@
     [
       "metr_nc",
       {
-        "col_label": "METR, non-corporate typically financed investment",
+        "col_label": "METR, non-corporate typically-financed investment",
         "name": "metr_nc",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate
+        investment financed by an historical mix of debt and equity.  The
+        debt-equity mix varies between corporate and non-corporate entities,
+        but is the same across industry and asset.  The METR includes only the
+        impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -33,10 +41,12 @@
     [
       "metr_c_e",
       {
-        "col_label": "METR, corporate equity financed investment",
+        "col_label": "METR, corporate equity-financed investment",
         "name": "metr_c_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate equity financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate
+        equity-financed investment.  The METR includes only the impact of the
+        first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -44,10 +54,12 @@
     [
       "metr_nc_e",
       {
-        "col_label": "METR, non-corporate equity financed investment",
+        "col_label": "METR, non-corporate equity-financed investment",
         "name": "metr_nc_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate equity financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate
+        equity-financed investment.  The METR includes only the impact of the
+        first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -55,10 +67,12 @@
     [
       "metr_c_d",
       {
-        "col_label": "METR, corporate debt financed investment",
+        "col_label": "METR, corporate debt-financed investment",
         "name": "metr_c_d",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate debt financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate
+        debt-financed investment.  The METR includes only the impact of the
+        first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -66,10 +80,12 @@
     [
        "metr_nc_d",
        {
-         "col_label": "METR, non-corporate debt financed investment",
+         "col_label": "METR, non-corporate debt-financed investment",
          "name": "metr_nc_d",
          "table_id": "metr",
-         "tooltip": "Marginal effective tax rate on new investments, non-corporate debt financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+         "tooltip": "Marginal effective tax rate on new investments, non-corporate
+         debts-financed investment.  The METR includes only the impact of the
+         first level of taxation on the incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -77,10 +93,15 @@
      [
        "mettr_c",
        {
-         "col_label": "METTR, corporate typically financed investment",
+         "col_label": "METTR, corporate typically-financed investment",
          "name": "mettr_c",
          "table_id": "mettr",
-         "tooltip": "Marginal effective total tax rate on new investments, corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+         "tooltip": "Marginal effective total tax rate on new investments,
+         corporate investment financed by an historical mix of debt and equity.
+         This mix varies between corporate and non-corporate entities, but is
+         the same across industry and asset.  The METTR includes the impact of
+         all levels of taxation (both on business entities and savers) on the
+         incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -88,10 +109,15 @@
     [
       "mettr_nc",
       {
-        "col_label": "METTR, non-corporate typically financed investment",
+        "col_label": "METTR, non-corporate typically-financed investment",
         "name": "mettr_nc",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        non-corporate investment financed by an historical mix of debt and equity.
+        This mix varies between corporate and non-corporate entities, but is
+        the same across industry and asset.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -99,10 +125,13 @@
     [
       "mettr_c_e",
       {
-        "col_label": "METTR, corporate equity financed investment",
+        "col_label": "METTR, corporate equity-financed investment",
         "name": "mettr_c_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, corporate equity financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        corporate equity-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -110,10 +139,13 @@
     [
       "mettr_nc_e",
       {
-        "col_label": "METTR, non-corporate equity financed investment",
+        "col_label": "METTR, non-corporate equity-financed investment",
         "name": "mettr_nc_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, non-corporate equity financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        non-corporate equity-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -121,10 +153,13 @@
     [
       "mettr_c_d",
       {
-        "col_label": "METTR, corporate debt financed investment",
+        "col_label": "METTR, corporate debt-financed investment",
         "name": "mettr_c_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, corporate debt financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        corporate debt-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -132,21 +167,27 @@
     [
       "mettr_nc_d",
       {
-        "col_label": "METTR, non-corporate debt financed investment",
+        "col_label": "METTR, non-corporate debt-financed investment",
         "name": "mettr_nc_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, non-corporate debt financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
-        "divisor": 1,
+        "tooltip": "Marginal effective total tax rate on new investments,
+        non-corporate debt-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.","divisor": 1,
         "decimals": 3
       }
     ],
     [
       "rho_c",
       {
-        "col_label": "Cost of capital, typically financed corporate investment",
+        "col_label": "Cost of capital, typically-financed corporate investment",
         "name": "rho_c",
         "table_id": "coc",
-        "tooltip": "Cost of capital, corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, corporate investment financed with an
+        historical mix of debt and equity.  This mix varies between corporate
+        and non-corporate entities, but is the same across industry and asset.
+        The cost of capital is calculated as the net-of-depreciation, before-tax
+        rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -154,10 +195,14 @@
     [
         "rho_nc",
         {
-          "col_label": "Cost of capital, typically financed non-corporate investment",
+          "col_label": "Cost of capital, typically-financed non-corporate investment",
           "name": "rho_nc",
           "table_id": "coc",
-          "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+          "tooltip": "Cost of capital, non-corporate investment financed with an
+          historical mix of debt and equity.  This mix varies between corporate
+          and non-corporate entities, but is the same across industry and asset.
+          The cost of capital is calculated as the net-of-depreciation, before-tax
+          rate of return.",
           "divisor": 1,
           "decimals": 3
         }
@@ -165,10 +210,11 @@
     [
       "rho_c_e",
       {
-        "col_label": "Cost of capital, equity financed corporate investment",
+        "col_label": "Cost of capital, equity-financed corporate investment",
         "name": "rho_c_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by equity.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -176,10 +222,11 @@
     [
       "rho_nc_e",
       {
-        "col_label": "Cost of capital, equity financed non-corporate investment",
+        "col_label": "Cost of capital, equity-financed non-corporate investment",
         "name": "rho_nc_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by equity.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed non-corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -187,10 +234,11 @@
     [
       "rho_c_d",
       {
-        "col_label": "Cost of capital, debt financed corporate investment",
+        "col_label": "Cost of capital, debt-financed corporate investment",
         "name": "rho_c_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by debt.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -198,10 +246,11 @@
     [
       "rho_nc_d",
       {
-        "col_label": "Cost of capital, debt financed non-corporate investment",
+        "col_label": "Cost of capital, debt-financed non-corporate investment",
         "name": "rho_nc_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by debt.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed non-corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -212,7 +261,10 @@
         "col_label": "NPV of depreciation deductions, typically financed corporate investment",
         "name": "z_c",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.",
+        "tooltip": "Net present value of depreciation deductions, corporate
+        investment financed with an historical mix of debt and equity.  This mix
+        varies between corporate and non-corporate entities, but is the same across
+        industry and asset.",
         "divisor": 1,
         "decimals": 3
       }
@@ -223,7 +275,10 @@
           "col_label": "NPV of depreciation deductions, typically financed non-corporate investment",
           "name": "z_nc",
           "table_id": "d",
-          "tooltip": "Net present value of depreciation deductions, non-corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.",
+          "tooltip": "Net present value of depreciation deductions, non-corporate
+          investment financed with an historical mix of debt and equity.  This mix
+          varies between corporate and non-corporate entities, but is the same across
+          industry and asset.",
           "divisor": 1,
           "decimals": 3
         }
@@ -231,10 +286,11 @@
     [
       "z_c_e",
       {
-        "col_label": "NPV of depreciation deductions, equity financed corporate investment",
+        "col_label": "NPV of depreciation deductions, equity-financed corporate investment",
         "name": "z_c_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by equity",
+        "tooltip": "Net present value of depreciation deductions, equity-financed
+        corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -242,10 +298,11 @@
     [
       "z_nc_e",
       {
-        "col_label": "NPV of depreciation deductions, equity financed non-corporate investment",
+        "col_label": "NPV of depreciation deductions, equity-financed non-corporate investment",
         "name": "z_nc_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by equity",
+        "tooltip": "Net present value of depreciation deductions, equity-financed
+        non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -253,10 +310,11 @@
     [
       "z_c_d",
       {
-        "col_label": "NPV of depreciation deductions, debt financed corporate investment",
+        "col_label": "NPV of depreciation deductions, debt-financed corporate investment",
         "name": "z_c_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by debt",
+        "tooltip": "Net present value of depreciation deductions, debt-financed
+        corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -264,10 +322,11 @@
     [
       "z_nc_d",
       {
-        "col_label": "NPV of depreciation deductions, debt financed non-corporate investment",
+        "col_label": "NPV of depreciation deductions, debt-financed non-corporate investment",
         "name": "z_nc_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by debt",
+        "tooltip": "Net present value of depreciation deductions, debt-financed
+        non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }

--- a/btax/param_defaults/btax_results_by_industry.json
+++ b/btax/param_defaults/btax_results_by_industry.json
@@ -8,13 +8,17 @@
         "table_id": "all"
       }
     ],
-        [
+    [
       "metr_c",
       {
-        "col_label": "METR, corporate typically financed investment",
+        "col_label": "METR, corporate typically-financed investment",
         "name": "metr_c",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate
+        investment financed by an historical mix of debt and equity.  The
+        debt-equity mix varies between corporate and non-corporate entities,
+        but is the same across industry and asset.  The METR includes
+        only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -22,10 +26,14 @@
     [
       "metr_nc",
       {
-        "col_label": "METR, non-corporate typically financed investment",
+        "col_label": "METR, non-corporate typically-financed investment",
         "name": "metr_nc",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate
+        investment financed by an historical mix of debt and equity.  The
+        debt-equity mix varies between corporate and non-corporate entities,
+        but is the same across industry and asset.  The METR includes only the
+        impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -33,10 +41,12 @@
     [
       "metr_c_e",
       {
-        "col_label": "METR, corporate equity financed investment",
+        "col_label": "METR, corporate equity-financed investment",
         "name": "metr_c_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate equity financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate
+        equity-financed investment.  The METR includes only the impact of the
+        first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -44,10 +54,12 @@
     [
       "metr_nc_e",
       {
-        "col_label": "METR, non-corporate equity financed investment",
+        "col_label": "METR, non-corporate equity-financed investment",
         "name": "metr_nc_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate equity financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate
+        equity-financed investment.  The METR includes only the impact of the
+        first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -55,10 +67,12 @@
     [
       "metr_c_d",
       {
-        "col_label": "METR, corporate debt financed investment",
+        "col_label": "METR, corporate debt-financed investment",
         "name": "metr_c_d",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate debt financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate
+        debt-financed investment.  The METR includes only the impact of the
+        first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -66,10 +80,12 @@
     [
        "metr_nc_d",
        {
-         "col_label": "METR, non-corporate debt financed investment",
+         "col_label": "METR, non-corporate debt-financed investment",
          "name": "metr_nc_d",
          "table_id": "metr",
-         "tooltip": "Marginal effective tax rate on new investments, non-corporate debt financed investment.  The METR includes the only impact of the first level of taxation on the incentives to invest.",
+         "tooltip": "Marginal effective tax rate on new investments, non-corporate
+         debts-financed investment.  The METR includes only the impact of the
+         first level of taxation on the incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -77,10 +93,15 @@
      [
        "mettr_c",
        {
-         "col_label": "METTR, corporate typically financed investment",
+         "col_label": "METTR, corporate typically-financed investment",
          "name": "mettr_c",
          "table_id": "mettr",
-         "tooltip": "Marginal effective total tax rate on new investments, corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+         "tooltip": "Marginal effective total tax rate on new investments,
+         corporate investment financed by an historical mix of debt and equity.
+         This mix varies between corporate and non-corporate entities, but is
+         the same across industry and asset.  The METTR includes the impact of
+         all levels of taxation (both on business entities and savers) on the
+         incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -88,10 +109,15 @@
     [
       "mettr_nc",
       {
-        "col_label": "METTR, non-corporate typically financed investment",
+        "col_label": "METTR, non-corporate typically-financed investment",
         "name": "mettr_nc",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, non-corporate investment financed by historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        non-corporate investment financed by an historical mix of debt and equity.
+        This mix varies between corporate and non-corporate entities, but is
+        the same across industry and asset.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -99,10 +125,13 @@
     [
       "mettr_c_e",
       {
-        "col_label": "METTR, corporate equity financed investment",
+        "col_label": "METTR, corporate equity-financed investment",
         "name": "mettr_c_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, corporate equity financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        corporate equity-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -110,10 +139,13 @@
     [
       "mettr_nc_e",
       {
-        "col_label": "METTR, non-corporate equity financed investment",
+        "col_label": "METTR, non-corporate equity-financed investment",
         "name": "mettr_nc_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, non-corporate equity financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        non-corporate equity-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -121,10 +153,13 @@
     [
       "mettr_c_d",
       {
-        "col_label": "METTR, corporate debt financed investment",
+        "col_label": "METTR, corporate debt-financed investment",
         "name": "mettr_c_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, corporate debt financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments,
+        corporate debt-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -132,21 +167,27 @@
     [
       "mettr_nc_d",
       {
-        "col_label": "METTR, non-corporate debt financed investment",
+        "col_label": "METTR, non-corporate debt-financed investment",
         "name": "mettr_nc_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments, non-corporate debt financed investment.  The METTR includes the only impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
-        "divisor": 1,
+        "tooltip": "Marginal effective total tax rate on new investments,
+        non-corporate debt-financed investment.  The METTR includes the impact of
+        all levels of taxation (both on business entities and savers) on the
+        incentives to invest.","divisor": 1,
         "decimals": 3
       }
     ],
     [
       "rho_c",
       {
-        "col_label": "Cost of capital, typically financed corporate investment",
+        "col_label": "Cost of capital, typically-financed corporate investment",
         "name": "rho_c",
         "table_id": "coc",
-        "tooltip": "Cost of capital, corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, corporate investment financed with an
+        historical mix of debt and equity.  This mix varies between corporate
+        and non-corporate entities, but is the same across industry and asset.
+        The cost of capital is calculated as the net-of-depreciation, before-tax
+        rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -154,10 +195,14 @@
     [
         "rho_nc",
         {
-          "col_label": "Cost of capital, typically financed non-corporate investment",
+          "col_label": "Cost of capital, typically-financed non-corporate investment",
           "name": "rho_nc",
           "table_id": "coc",
-          "tooltip": "Cost of capital, non-corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+          "tooltip": "Cost of capital, non-corporate investment financed with an
+          historical mix of debt and equity.  This mix varies between corporate
+          and non-corporate entities, but is the same across industry and asset.
+          The cost of capital is calculated as the net-of-depreciation, before-tax
+          rate of return.",
           "divisor": 1,
           "decimals": 3
         }
@@ -165,10 +210,11 @@
     [
       "rho_c_e",
       {
-        "col_label": "Cost of capital, equity financed corporate investment",
+        "col_label": "Cost of capital, equity-financed corporate investment",
         "name": "rho_c_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by equity.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -176,10 +222,11 @@
     [
       "rho_nc_e",
       {
-        "col_label": "Cost of capital, equity financed non-corporate investment",
+        "col_label": "Cost of capital, equity-financed non-corporate investment",
         "name": "rho_nc_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by equity.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed non-corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -187,10 +234,11 @@
     [
       "rho_c_d",
       {
-        "col_label": "Cost of capital, debt financed corporate investment",
+        "col_label": "Cost of capital, debt-financed corporate investment",
         "name": "rho_c_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by debt.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -198,10 +246,11 @@
     [
       "rho_nc_d",
       {
-        "col_label": "Cost of capital, debt financed non-corporate investment",
+        "col_label": "Cost of capital, debt-financed non-corporate investment",
         "name": "rho_nc_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, investment financed 100% by debt.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed non-corporate investment.  The cost of
+        capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -212,7 +261,10 @@
         "col_label": "NPV of depreciation deductions, typically financed corporate investment",
         "name": "z_c",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.",
+        "tooltip": "Net present value of depreciation deductions, corporate
+        investment financed with an historical mix of debt and equity.  This mix
+        varies between corporate and non-corporate entities, but is the same across
+        industry and asset.",
         "divisor": 1,
         "decimals": 3
       }
@@ -223,7 +275,10 @@
           "col_label": "NPV of depreciation deductions, typically financed non-corporate investment",
           "name": "z_nc",
           "table_id": "d",
-          "tooltip": "Net present value of depreciation deductions, non-corporate investment financed with historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across indusry and asset.",
+          "tooltip": "Net present value of depreciation deductions, non-corporate
+          investment financed with an historical mix of debt and equity.  This mix
+          varies between corporate and non-corporate entities, but is the same across
+          industry and asset.",
           "divisor": 1,
           "decimals": 3
         }
@@ -231,10 +286,11 @@
     [
       "z_c_e",
       {
-        "col_label": "NPV of depreciation deductions, equity financed corporate investment",
+        "col_label": "NPV of depreciation deductions, equity-financed corporate investment",
         "name": "z_c_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by equity",
+        "tooltip": "Net present value of depreciation deductions, equity-financed
+        corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -242,10 +298,11 @@
     [
       "z_nc_e",
       {
-        "col_label": "NPV of depreciation deductions, equity financed non-corporate investment",
+        "col_label": "NPV of depreciation deductions, equity-financed non-corporate investment",
         "name": "z_nc_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by equity",
+        "tooltip": "Net present value of depreciation deductions, equity-financed
+        non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -253,10 +310,11 @@
     [
       "z_c_d",
       {
-        "col_label": "NPV of depreciation deductions, debt financed corporate investment",
+        "col_label": "NPV of depreciation deductions, debt-financed corporate investment",
         "name": "z_c_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by debt",
+        "tooltip": "Net present value of depreciation deductions, debt-financed
+        corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -264,10 +322,11 @@
     [
       "z_nc_d",
       {
-        "col_label": "NPV of depreciation deductions, debt financed non-corporate investment",
+        "col_label": "NPV of depreciation deductions, debt-financed non-corporate investment",
         "name": "z_nc_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, investment financed 100% by debt",
+        "tooltip": "Net present value of depreciation deductions, debt-financed
+        non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }

--- a/btax/param_defaults/btax_results_by_industry.json
+++ b/btax/param_defaults/btax_results_by_industry.json
@@ -14,11 +14,7 @@
         "col_label": "METR, corporate typically-financed investment",
         "name": "metr_c",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate
-        investment financed by an historical mix of debt and equity.  The
-        debt-equity mix varies between corporate and non-corporate entities,
-        but is the same across industry and asset.  The METR includes
-        only the impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate investment financed by an historical mix of debt and equity.  The debt-equity mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -29,11 +25,7 @@
         "col_label": "METR, non-corporate typically-financed investment",
         "name": "metr_nc",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate
-        investment financed by an historical mix of debt and equity.  The
-        debt-equity mix varies between corporate and non-corporate entities,
-        but is the same across industry and asset.  The METR includes only the
-        impact of the first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate investment financed by an historical mix of debt and equity.  The debt-equity mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -44,9 +36,7 @@
         "col_label": "METR, corporate equity-financed investment",
         "name": "metr_c_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate
-        equity-financed investment.  The METR includes only the impact of the
-        first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate equity-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -57,9 +47,7 @@
         "col_label": "METR, non-corporate equity-financed investment",
         "name": "metr_nc_e",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, non-corporate
-        equity-financed investment.  The METR includes only the impact of the
-        first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, non-corporate equity-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -70,9 +58,7 @@
         "col_label": "METR, corporate debt-financed investment",
         "name": "metr_c_d",
         "table_id": "metr",
-        "tooltip": "Marginal effective tax rate on new investments, corporate
-        debt-financed investment.  The METR includes only the impact of the
-        first level of taxation on the incentives to invest.",
+        "tooltip": "Marginal effective tax rate on new investments, corporate debt-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -83,9 +69,7 @@
          "col_label": "METR, non-corporate debt-financed investment",
          "name": "metr_nc_d",
          "table_id": "metr",
-         "tooltip": "Marginal effective tax rate on new investments, non-corporate
-         debts-financed investment.  The METR includes only the impact of the
-         first level of taxation on the incentives to invest.",
+         "tooltip": "Marginal effective tax rate on new investments, non-corporate debts-financed investment.  The METR includes only the impact of the first level of taxation on the incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -96,12 +80,7 @@
          "col_label": "METTR, corporate typically-financed investment",
          "name": "mettr_c",
          "table_id": "mettr",
-         "tooltip": "Marginal effective total tax rate on new investments,
-         corporate investment financed by an historical mix of debt and equity.
-         This mix varies between corporate and non-corporate entities, but is
-         the same across industry and asset.  The METTR includes the impact of
-         all levels of taxation (both on business entities and savers) on the
-         incentives to invest.",
+         "tooltip": "Marginal effective total tax rate on new investments, corporate investment financed by an historical mix of debt and equity. This mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
          "divisor": 1,
          "decimals": 3
        }
@@ -112,12 +91,7 @@
         "col_label": "METTR, non-corporate typically-financed investment",
         "name": "mettr_nc",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        non-corporate investment financed by an historical mix of debt and equity.
-        This mix varies between corporate and non-corporate entities, but is
-        the same across industry and asset.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, non-corporate investment financed by an historical mix of debt and equity. This mix varies between corporate and non-corporate entities, but is the same across industry and asset.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -128,10 +102,7 @@
         "col_label": "METTR, corporate equity-financed investment",
         "name": "mettr_c_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        corporate equity-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, corporate equity-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -142,10 +113,7 @@
         "col_label": "METTR, non-corporate equity-financed investment",
         "name": "mettr_nc_e",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        non-corporate equity-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, non-corporate equity-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -156,10 +124,7 @@
         "col_label": "METTR, corporate debt-financed investment",
         "name": "mettr_c_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        corporate debt-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.",
+        "tooltip": "Marginal effective total tax rate on new investments, corporate debt-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
         "divisor": 1,
         "decimals": 3
       }
@@ -170,10 +135,8 @@
         "col_label": "METTR, non-corporate debt-financed investment",
         "name": "mettr_nc_d",
         "table_id": "mettr",
-        "tooltip": "Marginal effective total tax rate on new investments,
-        non-corporate debt-financed investment.  The METTR includes the impact of
-        all levels of taxation (both on business entities and savers) on the
-        incentives to invest.","divisor": 1,
+        "tooltip": "Marginal effective total tax rate on new investments, non-corporate debt-financed investment.  The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest.",
+        "divisor": 1,
         "decimals": 3
       }
     ],
@@ -183,11 +146,7 @@
         "col_label": "Cost of capital, typically-financed corporate investment",
         "name": "rho_c",
         "table_id": "coc",
-        "tooltip": "Cost of capital, corporate investment financed with an
-        historical mix of debt and equity.  This mix varies between corporate
-        and non-corporate entities, but is the same across industry and asset.
-        The cost of capital is calculated as the net-of-depreciation, before-tax
-        rate of return.",
+        "tooltip": "Cost of capital, corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset. The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -198,11 +157,7 @@
           "col_label": "Cost of capital, typically-financed non-corporate investment",
           "name": "rho_nc",
           "table_id": "coc",
-          "tooltip": "Cost of capital, non-corporate investment financed with an
-          historical mix of debt and equity.  This mix varies between corporate
-          and non-corporate entities, but is the same across industry and asset.
-          The cost of capital is calculated as the net-of-depreciation, before-tax
-          rate of return.",
+          "tooltip": "Cost of capital, non-corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset. The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
           "divisor": 1,
           "decimals": 3
         }
@@ -213,8 +168,7 @@
         "col_label": "Cost of capital, equity-financed corporate investment",
         "name": "rho_c_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, equity-financed corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -225,8 +179,7 @@
         "col_label": "Cost of capital, equity-financed non-corporate investment",
         "name": "rho_nc_e",
         "table_id": "coc",
-        "tooltip": "Cost of capital, equity-financed non-corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, equity-financed non-corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -237,8 +190,7 @@
         "col_label": "Cost of capital, debt-financed corporate investment",
         "name": "rho_c_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, debt-financed corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -249,8 +201,7 @@
         "col_label": "Cost of capital, debt-financed non-corporate investment",
         "name": "rho_nc_d",
         "table_id": "coc",
-        "tooltip": "Cost of capital, debt-financed non-corporate investment.  The cost of
-        capital is calculated as the net-of-depreciation, before-tax rate of return.",
+        "tooltip": "Cost of capital, debt-financed non-corporate investment.  The cost of capital is calculated as the net-of-depreciation, before-tax rate of return.",
         "divisor": 1,
         "decimals": 3
       }
@@ -261,10 +212,7 @@
         "col_label": "NPV of depreciation deductions, typically financed corporate investment",
         "name": "z_c",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, corporate
-        investment financed with an historical mix of debt and equity.  This mix
-        varies between corporate and non-corporate entities, but is the same across
-        industry and asset.",
+        "tooltip": "Net present value of depreciation deductions, corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset.",
         "divisor": 1,
         "decimals": 3
       }
@@ -275,10 +223,7 @@
           "col_label": "NPV of depreciation deductions, typically financed non-corporate investment",
           "name": "z_nc",
           "table_id": "d",
-          "tooltip": "Net present value of depreciation deductions, non-corporate
-          investment financed with an historical mix of debt and equity.  This mix
-          varies between corporate and non-corporate entities, but is the same across
-          industry and asset.",
+          "tooltip": "Net present value of depreciation deductions, non-corporate investment financed with an historical mix of debt and equity.  This mix varies between corporate and non-corporate entities, but is the same across industry and asset.",
           "divisor": 1,
           "decimals": 3
         }
@@ -289,8 +234,7 @@
         "col_label": "NPV of depreciation deductions, equity-financed corporate investment",
         "name": "z_c_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, equity-financed
-        corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, equity-financed corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -301,8 +245,7 @@
         "col_label": "NPV of depreciation deductions, equity-financed non-corporate investment",
         "name": "z_nc_e",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, equity-financed
-        non-corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, equity-financed non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -313,8 +256,7 @@
         "col_label": "NPV of depreciation deductions, debt-financed corporate investment",
         "name": "z_c_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, debt-financed
-        corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, debt-financed corporate investments.",
         "divisor": 1,
         "decimals": 3
       }
@@ -325,8 +267,7 @@
         "col_label": "NPV of depreciation deductions, debt-financed non-corporate investment",
         "name": "z_nc_d",
         "table_id": "d",
-        "tooltip": "Net present value of depreciation deductions, debt-financed
-        non-corporate investments.",
+        "tooltip": "Net present value of depreciation deductions, debt-financed non-corporate investments.",
         "divisor": 1,
         "decimals": 3
       }

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -258,9 +258,11 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
           'Other Equipment'))
     asset_dict.update(dict.fromkeys(['Residential'],
           'Residential Buildings'))
-    asset_dict.update(dict.fromkeys(['Manufacturing','Office','Hospitals','Special care','Medical buildings','Multimerchandise shopping',
+    asset_dict.update(dict.fromkeys(['Manufacturing','Office','Hospitals',
+          'Special care','Medical buildings','Multimerchandise shopping',
           'Food and beverage establishments','Warehouses','Other commercial',
-          'Air transportation','Other transportation','Religious','Educational and vocational','Lodging','Public safety'],
+          'Air transportation','Other transportation','Religious',
+          'Educational and vocational','Lodging','Public safety'],
           'Nonresidential Buildings'))
     asset_dict.update(dict.fromkeys(['Gas','Petroleum pipelines','Communication',
           'Petroleum and natural gas','Mining'],'Mining and Drilling Structures'))
@@ -280,6 +282,45 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
           'Private universities and colleges','Other nonprofit institutions','Theatrical movies','Long-lived television programs',
           'Books','Music','Other entertainment originals'],'Intellectual Property'))
 
+    # major asset groups
+    #major_asset_groups = {'Equipment','Structures','Intellectual Property','Inventories','Land'}
+    major_asset_groups = dict.fromkeys(['Mainframes','PCs','DASDs','Printers',
+          'Terminals','Tape drives','Storage devices','System integrators',
+          'Prepackaged software','Custom software','Own account software',
+          'Communications','Nonelectro medical instruments',
+          'Electro medical instruments','Nonmedical instruments','Photocopy and related equipment',
+          'Office and accounting equipment','Household furniture','Other furniture',
+          'Household appliances','Light trucks (including utility vehicles)',
+          'Other trucks, buses and truck trailers','Autos','Aircraft',
+          'Ships and boats','Railroad equipment','Steam engines',
+          'Internal combustion engines','Special industrial machinery',
+          'General industrial equipment','Nuclear fuel','Other fabricated metals',
+          'Metalworking machinery','Electric transmission and distribution',
+          'Other agricultural machinery','Farm tractors','Other construction machinery',
+          'Construction tractors','Mining and oilfield machinery',
+          'Service industry machinery','Other electrical','Other'],'Equipment')
+    major_asset_groups.update(dict.fromkeys(['Residential','Manufacturing',
+          'Office','Hospitals','Special care','Medical buildings','Multimerchandise shopping',
+          'Food and beverage establishments','Warehouses','Other commercial',
+          'Air transportation','Other transportation','Religious',
+          'Educational and vocational','Lodging','Public safety','Gas',
+          'Petroleum pipelines','Communication',
+          'Petroleum and natural gas','Mining','Electric','Wind and solar',
+          'Amusement and recreation',
+          'Other railroad','Track replacement','Local transit structures',
+          'Other land transportation','Farm','Water supply','Sewage and waste disposal',
+          'Highway and conservation and development','Mobile structures'],'Structures'))
+    major_asset_groups.update(dict.fromkeys(['Pharmaceutical and medicine manufacturing',
+          'Chemical manufacturing, ex. pharma and med','Semiconductor and other component manufacturing',
+          'Computers and peripheral equipment manufacturing','Communications equipment manufacturing',
+          'Navigational and other instruments manufacturing','Other computer and electronic manufacturing, n.e.c.',
+          'Motor vehicles and parts manufacturing','Aerospace products and parts manufacturing',
+          'Other manufacturing','Scientific research and development services','Software publishers',
+          'Financial and real estate services','Computer systems design and related services','All other nonmanufacturing, n.e.c.',
+          'Private universities and colleges','Other nonprofit institutions','Theatrical movies','Long-lived television programs',
+          'Books','Music','Other entertainment originals'],'Intellectual Property'))
+    major_asset_groups.update(dict.fromkeys(['Inventories'],'Inventories'))
+    major_asset_groups.update(dict.fromkeys(['Land'],'Land'))
     # define major industry groupings
     major_industries = {'Agriculture, forestry, fishing, and hunting', 'Mining',
       'Utilities', 'Construction',
@@ -376,6 +417,7 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
         'Y_v':Y_v,
         'phi':phi,
         'asset_dict': asset_dict,
-        'ind_dict': ind_dict
+        'ind_dict': ind_dict,
+        'major_asset_groups': major_asset_groups
     }
     return parameters

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -398,7 +398,40 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
     ind_dict.update(dict.fromkeys(['Other services, except government'],
                           'Other services, except government'))
 
-
+    bea_code_dict = dict.fromkeys(['110C','113F'],
+                              'Agriculture, forestry, fishing, and hunting')
+    bea_code_dict.update(dict.fromkeys(['2110','2120','2130'],'Mining'))
+    bea_code_dict.update(dict.fromkeys(['2200'],'Utilities'))
+    bea_code_dict.update(dict.fromkeys(['2300'],'Construction'))
+    bea_code_dict.update(dict.fromkeys(['3210','3270','3310','3320','3330','3340',
+                        '3350','336M','336O','3370','338A','311A','313T','315A',
+                        '3220','3230','3240','3250','3260'],'Manufacturing'))
+    bea_code_dict.update(dict.fromkeys(['4200'],'Wholesale trade'))
+    bea_code_dict.update(dict.fromkeys(['44RT'],'Retail trade'))
+    bea_code_dict.update(dict.fromkeys(['4810','4820','4830','4840','4850','4860',
+                        '487S','4930'],'Transportation and warehousing'))
+    bea_code_dict.update(dict.fromkeys(['5110','5120','5130','5140'],
+                                  'Information'))
+    bea_code_dict.update(dict.fromkeys(['5210','5220','5230','5240','5250'],
+                          'Finance and insurance'))
+    bea_code_dict.update(dict.fromkeys(['5310','5320'],
+                          'Real estate and rental and leasing'))
+    bea_code_dict.update(dict.fromkeys(['5411','5415','5412'],
+                          'Professional, scientific, and technical services'))
+    bea_code_dict.update(dict.fromkeys(['5500'],
+                          'Management of companies and enterprises'))
+    bea_code_dict.update(dict.fromkeys(['5610','5620'],
+                          'Administrative and waste management services'))
+    bea_code_dict.update(dict.fromkeys(['6100'],
+                          'Educational services'))
+    bea_code_dict.update(dict.fromkeys(['6210','622H','6230','6240'],
+                          'Health care and social assistance'))
+    bea_code_dict.update(dict.fromkeys(['711A','7130'],
+                          'Arts, entertainment, and recreation'))
+    bea_code_dict.update(dict.fromkeys(['7210','7220'],
+                          'Accommodation and food services'))
+    bea_code_dict.update(dict.fromkeys(['8100'],
+                          'Other services, except government'))
 
     parameters = {'inflation rate': pi,
         'econ depreciation': delta,
@@ -418,6 +451,7 @@ def get_params(test_run,baseline,start_year,iit_reform,**user_mods):
         'phi':phi,
         'asset_dict': asset_dict,
         'ind_dict': ind_dict,
-        'major_asset_groups': major_asset_groups
+        'major_asset_groups': major_asset_groups,
+        'bea_code_dict': bea_code_dict
     }
     return parameters

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -1,6 +1,3 @@
-
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Fixed Asset Breakdown (read_bea.py):
 -------------------------------------------------------------------------------

--- a/btax/read_bea.py
+++ b/btax/read_bea.py
@@ -1,3 +1,6 @@
+
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Fixed Asset Breakdown (read_bea.py):
 -------------------------------------------------------------------------------
@@ -78,7 +81,7 @@ def fixed_assets(soi_data):
       copy=True)
 
     # Read in cross-walk between IRS and BEA Industries
-    soi_bea_ind_codes = pd.read_csv(_SOI_BEA_CROSS, dtype={'bea_ind_code':str})
+    soi_bea_ind_codes = pd.read_csv(_SOI_BEA_CROSS, dtype={'bea_ind_code':str},encoding='utf-8')
     soi_bea_ind_codes.drop('notes', axis=1, inplace=True)
 
     # Merge SOI codes to BEA data
@@ -160,7 +163,7 @@ def land(soi_data, bea_FA):
 
     # read in Financial Accounts data on total value of real estate in
     # owner occ sector (includes land and structures)
-    b101 = pd.read_csv(_B101_PATH,header=5)
+    b101 = pd.read_csv(_B101_PATH,header=5,encoding='utf-8')
     b101.reset_index()
     b101 = b101[['Unnamed: 0','2013']].copy()
     b101.rename(columns={"Unnamed: 0":"Variable",

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -101,8 +101,8 @@ def run_btax_with_baseline_delta(test_run,start_year,iit_reform,**user_params):
 
     # create plots
     # by asset
-    visuals.asset_crossfilter(base_output_by_asset,'baseline')
-    visuals.asset_crossfilter(reform_output_by_asset,'reform')
+    #visuals.asset_crossfilter(base_output_by_asset,'baseline')
+    #visuals.asset_crossfilter(reform_output_by_asset,'reform')
     #visuals_plotly.asset_bubble(output_by_asset)
 
     # save output to csv - useful if run locally


### PR DESCRIPTION
This PR adds to the output by asset and industry calculations of the METRs (and other variables) by major asset/industry group and a rate for all investments.

There is also an update to fix some typos in the default json files.

This is  a WIP at the moment - the industry groupings aren't working because the industry names have some strange characters due to some encoding issue.  Therefore the industries aren't being matched to their major groups.

In addition, I don't know if this will pass the column tests since this PR adds columns.

There is also some issue when creating the differences between the baseline and reform by industry, I think due to the additional column being a string.  Will need to update this difference function in util.py to accommodate.