### PR TITLE
Fix ADS depreciation errors

### DIFF
--- a/btax/calc_z.py
+++ b/btax/calc_z.py
@@ -52,12 +52,7 @@ def calc_tax_depr_rates(r, delta, bonus_deprec, deprec_system, expense_inventory
 
     # update tax_deprec_rates based on user defined parameters
     tax_deprec_rates['System'] = tax_deprec_rates['GDS Life'].apply(str_modified)
-    #tax_deprec_rates['System'] = tax_deprec_rates['System']
-    # print 'TAX 1:'
-    # print tax_deprec_rates.head(n=50)
     tax_deprec_rates['System'].replace(deprec_system,inplace=True)
-    # print 'TAX 2:'
-    # print tax_deprec_rates.head(n=50)
     tax_deprec_rates.loc[tax_deprec_rates['System']=='ADS','Method'] = 'SL'
     tax_deprec_rates.loc[tax_deprec_rates['System']=='Economic','Method'] = 'Economic'
 
@@ -108,9 +103,6 @@ def npv_tax_deprec(df, r, tax_methods, financing_list, entity_list):
     """
     df['b'] = df['Method']
     df['b'].replace(tax_methods,inplace=True)
-    # print 'Tax Deprec:'
-    # print df.head(n=50)
-
 
     df_dbsl = dbsl(df.loc[(df['Method']=='DB 200%') | (df['Method']=='DB 150%')].copy(), r, financing_list, entity_list)
     df_sl = sl(df.loc[df['Method']=='SL'].copy(), r, financing_list, entity_list)
@@ -119,8 +111,6 @@ def npv_tax_deprec(df, r, tax_methods, financing_list, entity_list):
 
     # append gds and ads results
     df_all = df_dbsl.append(df_sl.append(df_econ.append(df_expense,ignore_index=True),ignore_index=True), ignore_index=True)
-    print 'Tax Deprec:'
-    print df_all.head(n=50)
 
     return df_all
 

--- a/btax/calc_z.py
+++ b/btax/calc_z.py
@@ -52,7 +52,12 @@ def calc_tax_depr_rates(r, delta, bonus_deprec, deprec_system, expense_inventory
 
     # update tax_deprec_rates based on user defined parameters
     tax_deprec_rates['System'] = tax_deprec_rates['GDS Life'].apply(str_modified)
+    #tax_deprec_rates['System'] = tax_deprec_rates['System']
+    # print 'TAX 1:'
+    # print tax_deprec_rates.head(n=50)
     tax_deprec_rates['System'].replace(deprec_system,inplace=True)
+    # print 'TAX 2:'
+    # print tax_deprec_rates.head(n=50)
     tax_deprec_rates.loc[tax_deprec_rates['System']=='ADS','Method'] = 'SL'
     tax_deprec_rates.loc[tax_deprec_rates['System']=='Economic','Method'] = 'Economic'
 
@@ -103,6 +108,9 @@ def npv_tax_deprec(df, r, tax_methods, financing_list, entity_list):
     """
     df['b'] = df['Method']
     df['b'].replace(tax_methods,inplace=True)
+    # print 'Tax Deprec:'
+    # print df.head(n=50)
+
 
     df_dbsl = dbsl(df.loc[(df['Method']=='DB 200%') | (df['Method']=='DB 150%')].copy(), r, financing_list, entity_list)
     df_sl = sl(df.loc[df['Method']=='SL'].copy(), r, financing_list, entity_list)
@@ -111,6 +119,8 @@ def npv_tax_deprec(df, r, tax_methods, financing_list, entity_list):
 
     # append gds and ads results
     df_all = df_dbsl.append(df_sl.append(df_econ.append(df_expense,ignore_index=True),ignore_index=True), ignore_index=True)
+    print 'Tax Deprec:'
+    print df_all.head(n=50)
 
     return df_all
 
@@ -159,12 +169,10 @@ def sl(df, r, financing_list, entity_list):
 
     """
     df['Y'] = df['ADS Life']
-    df['Y'] = df.loc[df['System']=='ADS','ADS Life']
-    df['Y'] = df.loc[df['System']=='GDS','GDS Life']
     for i in range(r.shape[0]):
         for j in range(r.shape[1]):
             df['z'+entity_list[j]+financing_list[i]] = \
-                df['bonus'] + ((1-df['bonus'])*((1-(np.exp(-1*r[i,j]*df['Y'])))/(r[i,j]*df['Y'])))
+                df['bonus'] + ((1-df['bonus'])*((1-np.exp(-1*r[i,j]*df['Y']))/(r[i,j]*df['Y'])))
 
     df.drop(['Y'], axis=1, inplace=True)
 

--- a/btax/data/depreciation_rates/tax_depreciation_rates.csv
+++ b/btax/data/depreciation_rates/tax_depreciation_rates.csv
@@ -48,7 +48,7 @@ Warehouses,39,39,40,GDS,SL
 Mobile structures,7,7,14,GDS,DB 200%
 Other commercial,39,39,40,GDS,SL
 Manufacturing,39,39,40,GDS,SL
-Electric,15,18,19,GDS,DB 150%
+Electric,15,15,19,GDS,DB 150%
 Wind and solar,5,5,5,GDS,DB 200%
 Gas,5,5,14,GDS,DB 200%
 Petroleum pipelines,5,5,14,GDS,DB 200%

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -44,6 +44,7 @@ def translate_param_names(start_year=DEFAULT_START_YEAR,**user_mods):
         if user_mods.get('btax_depr_{}yr_tax_Switch'.format(cl)):
             state = 'Economic'
         user_deprec_system[cl] = state
+    print user_deprec_system
 
     user_mods.update({k: v['value'][year] for k,v in defaults.iteritems()
                       if k not in user_mods})

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -44,7 +44,6 @@ def translate_param_names(start_year=DEFAULT_START_YEAR,**user_mods):
         if user_mods.get('btax_depr_{}yr_tax_Switch'.format(cl)):
             state = 'Economic'
         user_deprec_system[cl] = state
-    print user_deprec_system
 
     user_mods.update({k: v['value'][year] for k,v in defaults.iteritems()
                       if k not in user_mods})


### PR DESCRIPTION
This PR fixed the null results reported when the ADS depreciation system is selected.  The error was the result of a incorrect reference to a data frame element.  This has been fixed and results appear ok.