### PR TITLE
Fix sorting on final tables

### DIFF
--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -171,7 +171,7 @@ def asset_calcs(params,asset_data):
     output_by_asset.drop('index', axis=1,inplace=True)
 
     # sort output_by_asset dataframe
-    output_by_asset.sort(columns='Asset', inplace=True)
+    output_by_asset.sort_values('Asset', inplace=True)
 
     return output_by_asset
 
@@ -353,7 +353,7 @@ def industry_calcs(params, asset_data, output_by_asset):
     by_industry.drop('index', axis=1,inplace=True)
 
     # sort output_by_asset dataframe
-    by_industry.sort(columns='Industry', inplace=True)
+    by_industry.sort_values('Industry', inplace=True)
 
     return by_industry
 

--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -170,6 +170,9 @@ def asset_calcs(params,asset_data):
     output_by_asset = (output_by_asset.append([by_major_asset,overall],ignore_index=True)).copy().reset_index()
     output_by_asset.drop('index', axis=1,inplace=True)
 
+    # sort output_by_asset dataframe
+    output_by_asset.sort(columns='Asset', inplace=True)
+
     return output_by_asset
 
 
@@ -348,6 +351,9 @@ def industry_calcs(params, asset_data, output_by_asset):
     by_major_ind = by_major_ind[by_major_ind['major_industry']!='Other services, except government'].copy()
     by_industry = (by_industry.append([by_major_ind,overall],ignore_index=True)).copy().reset_index()
     by_industry.drop('index', axis=1,inplace=True)
+
+    # sort output_by_asset dataframe
+    by_industry.sort(columns='Industry', inplace=True)
 
     return by_industry
 

--- a/btax/get_taxcalc_rates.py
+++ b/btax/get_taxcalc_rates.py
@@ -26,37 +26,6 @@ import copy
 import numba
 import pickle
 
-def only_growth_assumptions(user_mods, start_year):
-    """
-    Extract any reform parameters that are pertinent to growth
-    assumptions
-    """
-    growth_dd = taxcalc.growth.Growth.default_data(start_year=start_year)
-    ga = {}
-    for year, reforms in user_mods.items():
-        overlap = set(growth_dd.keys()) & set(reforms.keys())
-        if overlap:
-            ga[year] = {param:reforms[param] for param in overlap}
-    return ga
-
-
-def only_reform_mods(user_mods, start_year):
-    """
-    Extract parameters that are just for policy reforms
-    """
-    pol_refs = {}
-    beh_dd = Behavior.default_data(start_year=start_year)
-    growth_dd = taxcalc.growth.Growth.default_data(start_year=start_year)
-    policy_dd = taxcalc.policy.Policy.default_data(start_year=start_year)
-    for year, reforms in user_mods.items():
-        all_cpis = {p for p in reforms.keys() if p.endswith("_cpi") and
-                    p[:-4] in policy_dd.keys()}
-        pols = set(reforms.keys()) - set(beh_dd.keys()) - set(growth_dd.keys())
-        pols &= set(policy_dd.keys())
-        pols ^= all_cpis
-        if pols:
-            pol_refs[year] = {param:reforms[param] for param in pols}
-    return pol_refs
 
 def get_calculator(baseline, calculator_start_year, reform=None, data=None,
 weights=None, records_start_year=None):
@@ -88,17 +57,11 @@ weights=None, records_start_year=None):
         #Should not be a reform if baseline is True
         assert not reform
 
-    growth_assumptions = only_growth_assumptions(reform, calculator_start_year)
-    reform_mods = only_reform_mods(reform, calculator_start_year)
-
     if not baseline:
-        policy1.implement_reform(reform_mods)
+        policy1.implement_reform(reform)
 
     # the default set up increments year to 2013
     calc1 = Calculator(records=records1, policy=policy1)
-
-    if growth_assumptions:
-        calc1.growth.update_growth(growth_assumptions)
 
     # this increment_year function extrapolates all PUF variables to the next year
     # so this step takes the calculator to the start_year


### PR DESCRIPTION
This PR does 2 things:
1) Sorts the final tables of output.  This corrects some errors when differencing tables.
2) Makes B-Tax compatible with Tax Calc 0.7.7 by removing the passing of growth assumptions which was unused anyway.