### PR TITLE
fix numpy and pandas versions

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,8 +10,8 @@ requirements:
     - setuptools
     - scipy
     - taxcalc
-    - numpy
-    - pandas <=0.18.0
+    - numpy >=1.12.1
+    - pandas >=0.20.1
     - python
     - pytest
     - xlrd
@@ -21,8 +21,8 @@ requirements:
     - setuptools
     - scipy
     - taxcalc
-    - numpy
-    - pandas <=0.18.0
+    - numpy >=1.12.1
+    - pandas >=0.20.1
     - python
     - pytest
     - xlrd


### PR DESCRIPTION
Fix B-Tax numpy and pandas versions to be like `taxcalc=0.8.4` - See also [Tax-Calculator Issue 
 31](https://github.com/open-source-economics/policybrain-builder/issues/31)