### PR TITLE
Make consistent with Pandas 0.20.0

### DIFF
--- a/btax/pull_soi_partner.py
+++ b/btax/pull_soi_partner.py
@@ -109,7 +109,7 @@ def load_partner_data(entity_dfs):
 
     # Sums together the repeated codes into one industry
     df03 = df03.groupby('INDY_CD',sort=False).sum()
-    df03.reset_index(level=0, inplace=True)
+    df03.reset_index(inplace=True)
 
     ## create ratios for minor industry assets using corporate data
     # read in crosswalk for bea and soi industry codes

--- a/btax/pull_soi_proprietorship.py
+++ b/btax/pull_soi_proprietorship.py
@@ -82,7 +82,7 @@ def load_proprietorship_data(entity_dfs):
 
     # Sums together the repeated codes into one industry
     nonfarm_df = nonfarm_df.groupby('INDY_CD',sort=False).sum()
-    nonfarm_df.reset_index(level=0, inplace=True)
+    nonfarm_df.reset_index(inplace=True)
 
     # add some rows for industry codes not in the sole prop data because they are zero
     df = pd.DataFrame(columns=('INDY_CD','Depreciation','Inventories'))


### PR DESCRIPTION
This PR changes calls to the data frame method `reset_index` so as to be consistent with Pandas 0.20.0.  

The `asset_data.pkl` file is also updated to be consistent with the new Pandas version.