### PR TITLE
Comment out visuals.py import

### DIFF
--- a/btax/execute.py
+++ b/btax/execute.py
@@ -32,8 +32,8 @@ from btax import read_bea
 import btax.soi_processing as soi
 import btax.parameters as params
 from btax import format_output
-from btax import visuals
-from btax import visuals_plotly
+# from btax import visuals
+# from btax import visuals_plotly
 from btax.front_end_util import (runner_json_tables,
                                  replace_unicode_spaces)
 from btax.util import DEFAULT_START_YEAR

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -33,8 +33,8 @@ from btax import read_bea
 import btax.soi_processing as soi
 import btax.parameters as params
 from btax import format_output
-from btax import visuals
-from btax import visuals_plotly
+# from btax import visuals
+# from btax import visuals_plotly
 from btax.front_end_util import (runner_json_tables,
                                  replace_unicode_spaces)
 from btax.util import DEFAULT_START_YEAR


### PR DESCRIPTION
This PR comments out the import of `visuals.py` and `visuals_plotly.py`.  The are scripts that are inactive, but will be left in as a placeholder for the work of @DoraSzasz.  Commenting these out helps avoid the need to import bokeh.

Also in the PR  the `asset_data.pkl` file is updated to conform to pickle with Python 3.x