### PR TITLE
Pass all dataframes in serialized format

### DIFF
--- a/btax/tests/test_params_have_effect.py
+++ b/btax/tests/test_params_have_effect.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import re
 
 import pytest
+import json
 
 from btax.parameters import DEFAULTS, get_params, translate_param_names
 from btax.execute import runner
@@ -19,7 +20,9 @@ def tst_once(fast_or_slow, **user_params):
     if fast_or_slow == 'slow':
         # actually run the model
         # and look at the "changed" tables
-        tables = runner_json_tables(**user_params)
+        json_out = runner_json_tables(**user_params)
+        dict_out = json.loads(json_out)
+        tables = dict_out['json_table']
         assert isinstance(tables, dict)
         for k, v in tables.items():
             if k in ('row_grouping', 'result_years',):


### PR DESCRIPTION
This PR updates `btax.front_end_util.runner_json_tables()` to pass all data frames in a serialized format.