### PR TITLE
Add EATR calculations

### DIFF
--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -27,9 +27,22 @@ def cost_of_capital(df, w, expense_inventory, stat_tax, inv_credit, phi,
     Compute the cost of capital and the user cost of capital
 
     Args:
+        df: DataFrame, assets by type with depreciation rates
+        w: scalar, property tax rate
+        expense_inventory: boolean, whether inventories are expensed
+        stat_tax: Numpy array, entity level taxes for corp and noncorp
+        inv_credit: scalar, investment tax credit
+        phi: scalar, fraction of inventories using FIFO
+        Y_v: integer, number of years inventories held
+        inflation_rate: scalar, rate of inflation
+        discount_rate: Numpy array, discount rate used by entity type
+                                    and financing used
+        entity_list: list, identifiers for entity type
+        financing_list: list, indentifiers for financing used
 
-
-    Results:
+    Returns:
+        df: DataFrame, assets by type with depreciation and cost of
+                      capital
 
     """
     # calculate the cost of capital, metr, mettr
@@ -65,9 +78,18 @@ def metr(df, r_prime, inflation_rate, save_rate, entity_list,
     Compute the METR and METTR
 
     Args:
+        df: DataFrame, assets by type with depreciation rates and cost
+                       of capital
+        r_prime: Numpy array, discount rate used by entity type
+                                    and financing used
+        inflation_rate: scalar, rate of inflation
+        save_rate: Numpy array, after-tax return on savings
+        entity_list: list, identifiers for entity type
+        financing_list: list, indentifiers for financing used
 
-
-    Results:
+    Returns:
+        df: DataFrame, assets by type with depreciation and cost of
+                      capital and METR and METTR and tax wedge
 
     """
     for i in range(save_rate.shape[0]):
@@ -80,6 +102,37 @@ def metr(df, r_prime, inflation_rate, save_rate, entity_list,
                 ((df['rho' + entity_list[j] + financing_list[i]] -
                   save_rate[i, j]) /
                  df['rho' + entity_list[j] + financing_list[i]])
+            df['tax_wedge' + entity_list[j] + financing_list[i]] = \
+                ((df['rho' + entity_list[j] + financing_list[i]] -
+                  save_rate[i, j]))
+
+    return df
+
+
+def eatr(df, p, stat_tax, entity_list, financing_list):
+    """
+    Compute the EATR
+
+    Args:
+        df: DataFrame, assets by type with depreciation rates and cost
+                       of capital and METR
+        p: scalar, profit rate
+        stat_tax: Numpy array, entity level taxes for corp and noncorp
+        entity_list: list, identifiers for entity type
+        financing_list: list, indentifiers for financing used
+
+    Returns:
+        df: DataFrame, assets by type with depreciation and cost of
+                      capital and METR and METTR and EATR
+    """
+    for i in range(len(financing_list)):
+        for j in range(len(entity_list)):
+            df['eatr' + entity_list[j] + financing_list[i]] = \
+                ((((p - df['rho' + entity_list[j] + financing_list[i]]) /
+                 p) * stat_tax[j]) + ((df['rho' + entity_list[j] +
+                                          financing_list[i]] / p) *
+                                      df['metr' + entity_list[j] +
+                                         financing_list[i]]))
 
     return df
 
@@ -107,6 +160,7 @@ def asset_calcs(params, asset_data):
     z = params['depr allow']
     Y_v = params['Y_v']
     phi = params['phi']
+    p = params['p']
     expense_inventory = params['expense_inventory']
     financing_list = params['financing_list']
     entity_list = params['entity_list']
@@ -124,7 +178,7 @@ def asset_calcs(params, asset_data):
     output_by_asset = output_by_asset[output_by_asset['Asset Type'] !=
                                       'Other nonprofit institutions'].copy()
 
-    # calculate the cost of capital, metr, mettr
+    # calculate the cost of capital, metr, mettr, eatr
     output_by_asset = cost_of_capital(output_by_asset, w,
                                       expense_inventory, stat_tax,
                                       inv_credit, phi, Y_v,
@@ -132,6 +186,7 @@ def asset_calcs(params, asset_data):
                                       entity_list, financing_list)
     output_by_asset = metr(output_by_asset, r_prime, inflation_rate, save_rate,
                            entity_list, financing_list)
+    output_by_asset = eatr(output_by_asset, p)
 
     # create asset category variable
     output_by_asset['asset_category'] = output_by_asset['Asset Type']
@@ -202,9 +257,11 @@ def asset_calcs(params, asset_data):
                       groupby(['major_asset_group'])['assets_nc'].
                       sum()})).reset_index()['assets_nc']
 
-    # calculate the cost of capital, metr, mettr
+    # calculate metr, mettr
     by_major_asset = metr(by_major_asset, r_prime, inflation_rate,
                           save_rate, entity_list, financing_list)
+    by_major_asset = eatr(by_major_asset, p, stat_tax, entity_list,
+                          financing_list)
 
     # make asset type = major asset group in by_major_asset
     by_major_asset['Asset'] = by_major_asset['major_asset_group']
@@ -239,6 +296,7 @@ def asset_calcs(params, asset_data):
     # calculate the cost of capital, metr, mettr
     overall = metr(overall, r_prime, inflation_rate, save_rate,
                    entity_list, financing_list)
+    overall = eatr(overall, p, stat_tax, entity_list, financing_list)
 
     # append by_major_asset to output_by_asset
     # drop asset types that are only one in major group
@@ -278,6 +336,7 @@ def industry_calcs(params, asset_data, output_by_asset):
     r_prime = params['after-tax rate']
     financing_list = params['financing_list']
     entity_list = params['entity_list']
+    p = params['p']
     bea_code_dict = params['bea_code_dict']
 
     # initialize dataframe - start w/ fixed assets by industry and asset type
@@ -335,9 +394,11 @@ def industry_calcs(params, asset_data, output_by_asset):
                        groupby(['bea_ind_code', 'tax_treat'])['assets'].
                        sum()})).reset_index()['assets']
 
-    # calculate metr and mettr
+    # calculate metr and mettr and eatr
     by_industry_tax = metr(by_industry_tax, r_prime, inflation_rate,
                            save_rate, entity_list, financing_list)
+    by_industry_tax = eatr(by_industry_tax, p, stat_tax, entity_list,
+                           financing_list)
 
     # put together in different format (later we should consider changing how
     # output is handled and do long format)
@@ -349,12 +410,15 @@ def industry_calcs(params, asset_data, output_by_asset):
                  'rho_c', 'rho_c_d', 'rho_c_e', 'ucc_c', 'ucc_c_d',
                  'ucc_c_e', 'metr_c', 'metr_c_d',
                  'metr_c_e', 'mettr_c', 'mettr_c_d', 'mettr_c_e',
-                 'assets']].copy()
+                  'tax_wedge_c', 'tax_wedge_c_d', 'tax_wedge_c_e',
+                  'eatr_c', 'eatr_c_d', 'eatr_c_e', 'assets']].copy()
     non_corp = non_corp[['bea_ind_code', 'delta', 'z_nc', 'z_nc_d',
                          'z_nc_e', 'rho_nc', 'rho_nc_d', 'rho_nc_e',
                          'ucc_nc', 'ucc_nc_d', 'ucc_nc_e',
                          'metr_nc', 'metr_nc_d', 'metr_nc_e', 'mettr_nc',
-                         'mettr_nc_d', 'mettr_nc_e', 'assets']].copy()
+                         'mettr_nc_d', 'mettr_nc_e', 'tax_wedge_nc',
+                         'tax_wedge_nc_d', 'tax_wedge_nc_e', 'eatr_nc',
+                         'eatr_nc_d', 'eatr_nc_e', 'assets']].copy()
     corp.rename(columns={"delta": "delta_c", "assets": "assets_c"},
                 inplace=True)
     non_corp.rename(columns={"delta": "delta_nc", "assets": "assets_nc"},
@@ -401,9 +465,11 @@ def industry_calcs(params, asset_data, output_by_asset):
                        groupby(['major_industry', 'tax_treat'])['assets'].
                        sum()})).reset_index()['assets']
 
-    # calculate metr and mettr
+    # calculate metr and mettr and eatr
     by_major_ind_tax = metr(by_major_ind_tax, r_prime, inflation_rate,
                             save_rate, entity_list, financing_list)
+    by_major_ind_tax = eatr(by_major_ind_tax, p, stat_tax, entity_list,
+                            financing_list)
 
     # put together in different format (later we should consider
     # changing how output is handled and do long format)
@@ -415,12 +481,15 @@ def industry_calcs(params, asset_data, output_by_asset):
                  'rho_c', 'rho_c_d', 'rho_c_e', 'ucc_c', 'ucc_c_d',
                  'ucc_c_e', 'metr_c', 'metr_c_d',
                  'metr_c_e', 'mettr_c', 'mettr_c_d', 'mettr_c_e',
-                 'assets']].copy()
+                 'tax_wedge_c', 'tax_wedge_c_d', 'tax_wedge_c_e',
+                 'eatr_c', 'eatr_c_d', 'eatr_c_e', 'assets']].copy()
     non_corp = non_corp[['major_industry', 'delta', 'z_nc', 'z_nc_d',
                          'z_nc_e', 'rho_nc', 'rho_nc_d', 'rho_nc_e',
                          'ucc_nc', 'ucc_nc_d', 'ucc_nc_e',
                          'metr_nc', 'metr_nc_d', 'metr_nc_e', 'mettr_nc',
-                         'mettr_nc_d', 'mettr_nc_e', 'assets']].copy()
+                         'mettr_nc_d', 'mettr_nc_e', 'tax_wedge_nc',
+                         'tax_wedge_nc_d', 'tax_wedge_nc_e', 'eatr_nc',
+                         'eatr_nc_d', 'eatr_nc_e', 'assets']].copy()
     corp.rename(columns={"delta": "delta_c", "assets": "assets_c"},
                 inplace=True)
     non_corp.rename(columns={"delta": "delta_nc", "assets": "assets_nc"},
@@ -465,9 +534,10 @@ def industry_calcs(params, asset_data, output_by_asset):
         overall[item] = ((output_by_asset[item] *
                           output_by_asset['assets_nc']).sum() /
                          output_by_asset['assets_nc'].sum())
-    # calculate metr and mettr
+    # calculate metr and mettr and eatr
     overall = metr(overall, r_prime, inflation_rate, save_rate,
                    entity_list, financing_list)
+    overall = eatr(overall, p, stat_tax, entity_list, financing_list)
 
     # append by_major_asset to output_by_asset
     # drop major inds when only one in major group

--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -184,9 +184,10 @@ def asset_calcs(params, asset_data):
                                       inv_credit, phi, Y_v,
                                       inflation_rate, discount_rate,
                                       entity_list, financing_list)
-    output_by_asset = metr(output_by_asset, r_prime, inflation_rate, save_rate,
-                           entity_list, financing_list)
-    output_by_asset = eatr(output_by_asset, p)
+    output_by_asset = metr(output_by_asset, r_prime, inflation_rate,
+                           save_rate, entity_list, financing_list)
+    output_by_asset = eatr(output_by_asset, p, stat_tax, entity_list,
+                           financing_list)
 
     # create asset category variable
     output_by_asset['asset_category'] = output_by_asset['Asset Type']
@@ -337,6 +338,7 @@ def industry_calcs(params, asset_data, output_by_asset):
     financing_list = params['financing_list']
     entity_list = params['entity_list']
     p = params['p']
+    stat_tax = params['tax rate']
     bea_code_dict = params['bea_code_dict']
 
     # initialize dataframe - start w/ fixed assets by industry and asset type

--- a/btax/calc_final_outputs.py
+++ b/btax/calc_final_outputs.py
@@ -139,7 +139,7 @@ def eatr(df, p, stat_tax, entity_list, financing_list):
 
 def asset_calcs(params, asset_data):
     """
-    Computes rho, METR, and METTR by asset type.
+    Computes rho, ucc, METR, METTR, tax wedge, EATR by asset type.
 
     Args:
         params: dictionary, Constants used in the calculation

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -232,6 +232,7 @@ def get_params(test_run, baseline, start_year, iit_reform, **user_mods):
 
     # Miscellaneous parameters
     m = 0.44  # Divident payout rate
+    p = 0.2  # Profit rate to compute EATR
 
     # Intermediate variables
     sprime_c_td = ((1 / Y_td) * np.log(((1 - tau_td) * np.exp(i * Y_td))
@@ -611,7 +612,7 @@ def get_params(test_run, baseline, start_year, iit_reform, **user_mods):
                   'int_haircut': int_haircut,
                   'financing_list': financing_list,
                   'entity_list': entity_list,
-                  'delta': delta, 'Y_v': Y_v, 'phi': phi,
+                  'delta': delta, 'Y_v': Y_v, 'phi': phi, 'p': p,
                   'expense_inventory': expense_inventory,
                   'asset_dict': asset_dict,
                   'ind_dict': ind_dict,

--- a/btax/tests/test_calc_final_outputs.py
+++ b/btax/tests/test_calc_final_outputs.py
@@ -198,6 +198,92 @@ def test_metr(inflation_rate, expected):
                        check_less_precise=True)
 
 
+correct_df0 = pd.DataFrame(
+    {'Asset Type': ['Inventories', 'Autos'],
+     'delta': [0.0, 0.1],
+     'rho_c': [0.042780, 0.075286],
+     'rho_c_d': [0.029723, 0.042000],
+     'rho_c_e': [0.115883, 0.114476],
+     'rho_nc': [0.0400, 0.0388],
+     'rho_nc_d': [0.0100, 0.0112],
+     'rho_nc_e': [0.100, 0.094],
+     'metr_c': [0.298738, 0.601520],
+     'metr_c_d': [0.32712, 0.52381],
+     'metr_c_e': [0.223355, 0.213809],
+     'metr_nc': [0, -0.03092784],
+     'metr_nc_d': [0, 0.1071429],
+     'metr_nc_e': [0.0, -0.06382979],
+     'eatr_c': [0.299459779, 0.527],
+     'eatr_c_d': [0.308062784, 0.394],
+     'eatr_c_e': [0.211177821, 0.2013308],
+     'eatr_nc': [0.0, -0.012],
+     'eatr_nc_d': [0.0, 0.012],
+     'eatr_nc_e': [0.0, -0.06]})
+correct_df1 = pd.DataFrame(
+    {'Asset Type': ['Inventories', 'Autos'],
+     'delta': [0.0, 0.1],
+     'rho_c': [0.042780, 0.075286],
+     'rho_c_d': [0.029723, 0.042000],
+     'rho_c_e': [0.115883, 0.114476],
+     'rho_nc': [0.0400, 0.0388],
+     'rho_nc_d': [0.0100, 0.0112],
+     'rho_nc_e': [0.100, 0.094],
+     'metr_c': [0.298738, 0.601520],
+     'metr_c_d': [0.32712, 0.52381],
+     'metr_c_e': [0.223355, 0.213809],
+     'metr_nc': [0, -0.03092784],
+     'metr_nc_d': [0, 0.1071429],
+     'metr_nc_e': [0.0, -0.06382979],
+     'eatr_c': [0.298737211, 0.830621786],
+     'eatr_c_d': [0.318847088, 0.519728845],
+     'eatr_c_e': [0.092374524, 0.069356709],
+     'eatr_nc': [0.0, -0.028050491],
+     'eatr_nc_d': [0.0, 0.028050491],
+     'eatr_nc_e': [0.0, -0.140252454]})
+test_data = [(0.10, correct_df0), (0.042780, correct_df1)]
+
+
+@pytest.mark.parametrize('p,expected', test_data,
+                         ids=['p=0.10', 'p=0.042780'])
+def test_eatr(p, expected):
+    # Test METR and METTR calculations
+    df = pd.DataFrame(
+        {'Asset Type': ['Inventories', 'Autos'],
+         'delta': [0.0, 0.1],
+         'rho_c': [0.042780, 0.075286],
+         'rho_c_d': [0.029723, 0.042000],
+         'rho_c_e': [0.115883, 0.114476],
+         'rho_nc': [0.0400, 0.0388],
+         'rho_nc_d': [0.0100, 0.0112],
+         'rho_nc_e': [0.100, 0.094],
+         'metr_c': [0.298738, 0.601520],
+         'metr_c_d': [0.32712, 0.52381],
+         'metr_c_e': [0.223355, 0.213809],
+         'metr_nc': [0, -0.03092784],
+         'metr_nc_d': [0, 0.1071429],
+         'metr_nc_e': [0.0, -0.06382979]})
+    stat_tax = np.array([0.3, 0.0])
+    financing_list = ['', '_d', '_e']
+    entity_list = ['_c', '_nc']
+    test_df = calc_final_outputs.eatr(df, p, stat_tax, entity_list,
+                                      financing_list)
+    expected = expected[['Asset Type', 'delta', 'rho_c', 'rho_c_d',
+                         'rho_c_e', 'rho_nc', 'rho_nc_d', 'rho_nc_e',
+                         'metr_c', 'eatr_c', 'metr_nc', 'eatr_nc',
+                         'metr_c_d', 'eatr_c_d', 'metr_nc_d',
+                         'eatr_nc_d', 'metr_c_e', 'eatr_c_e',
+                         'metr_nc_e', 'eatr_nc_e']]
+    test_df = test_df[['Asset Type', 'delta', 'rho_c', 'rho_c_d',
+                         'rho_c_e', 'rho_nc', 'rho_nc_d', 'rho_nc_e',
+                         'metr_c', 'eatr_c', 'metr_nc', 'eatr_nc',
+                         'metr_c_d', 'eatr_c_d', 'metr_nc_d',
+                         'eatr_nc_d', 'metr_c_e', 'eatr_c_e',
+                         'metr_nc_e', 'eatr_nc_e']]
+
+    assert_frame_equal(test_df, expected, check_dtype=False,
+                       check_less_precise=True)
+
+
 # def test_asset_calcs():
 #
 #     assert_frame_equal(test_df, correct_df, check_dtype=False)

--- a/btax/tests/test_calc_final_outputs.py
+++ b/btax/tests/test_calc_final_outputs.py
@@ -126,9 +126,15 @@ correct_df0 = pd.DataFrame(
      'mettr_c': [0.228612, 0.561671],
      'mettr_c_d': [0.32712, 0.52381],
      'mettr_c_e': [-0.121821, -0.135609],
-     'mettr_nc': [0.0, -0.030928],
+     'mettr_nc': [0.0, -0.030927835],
      'mettr_nc_d': [-24.000000, -21.321429],
-     'mettr_nc_e': [0.88000, 0.87234]})
+     'mettr_nc_e': [0.88000, 0.87234],
+     'tax_wedge_c': [0.009779968, 0.042285714],
+     'tax_wedge_c_d': [0.009723255, 0.022],
+     'tax_wedge_c_e': [-0.014117454, -0.015524171],
+     'tax_wedge_nc': [0.0, -0.0012],
+     'tax_wedge_nc_d': [-0.24, -0.2388],
+     'tax_wedge_nc_e': [0.088, 0.082]})
 correct_df1 = pd.DataFrame(
     {'Asset Type': ['Inventories', 'Autos'],
      'delta': [0.0, 0.1],
@@ -149,7 +155,13 @@ correct_df1 = pd.DataFrame(
      'mettr_c_e': [-0.121821, -0.135609],
      'mettr_nc': [0.0, -0.030928],
      'mettr_nc_d': [-24.000000, -21.321429],
-     'mettr_nc_e': [0.88000, 0.87234]})
+     'mettr_nc_e': [0.88000, 0.87234],
+     'tax_wedge_c': [0.009779968, 0.042285714],
+     'tax_wedge_c_d': [0.009723255, 0.022],
+     'tax_wedge_c_e': [-0.014117454, -0.015524171],
+     'tax_wedge_nc': [0.0, -0.0012],
+     'tax_wedge_nc_d': [-0.24, -0.2388],
+     'tax_wedge_nc_e': [0.088, 0.082]})
 test_data = [(0.02, correct_df0), (0.05, correct_df1)]
 
 
@@ -175,10 +187,12 @@ def test_metr(inflation_rate, expected):
                                       financing_list)
     expected = expected[['Asset Type', 'delta', 'rho_c', 'rho_c_d',
                          'rho_c_e', 'rho_nc', 'rho_nc_d', 'rho_nc_e',
-                         'metr_c', 'mettr_c', 'metr_nc', 'mettr_nc',
-                         'metr_c_d', 'mettr_c_d', 'metr_nc_d',
-                         'mettr_nc_d', 'metr_c_e', 'mettr_c_e',
-                         'metr_nc_e', 'mettr_nc_e']]
+                         'metr_c', 'mettr_c', 'tax_wedge_c', 'metr_nc',
+                         'mettr_nc', 'tax_wedge_nc', 'metr_c_d',
+                         'mettr_c_d', 'tax_wedge_c_d', 'metr_nc_d',
+                         'mettr_nc_d', 'tax_wedge_nc_d', 'metr_c_e',
+                         'mettr_c_e', 'tax_wedge_c_e', 'metr_nc_e',
+                         'mettr_nc_e', 'tax_wedge_nc_e']]
 
     assert_frame_equal(test_df, expected, check_dtype=False,
                        check_less_precise=True)


### PR DESCRIPTION
This PR added Devereux-Griffith (1998) Effective Average Tax Rate (EATR) calculations are part of the B-Tax output.

The PR also adds the "tax wedge" (computed as the difference between the before tax rate of return and the required after-tax rate of return).