### PR TITLE
Pin taxcalc version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   build:
     - setuptools
     - scipy
-    - taxcalc
+    - taxcalc==0.15.1
     - numpy >=1.12.1
     - pandas >=0.20.1
     - python
@@ -20,7 +20,7 @@ requirements:
   run:
     - setuptools
     - scipy
-    - taxcalc
+    - taxcalc==0.15.1
     - numpy >=1.12.1
     - pandas >=0.20.1
     - python


### PR DESCRIPTION
This PR updates the `meta.yaml` file to pin the Tax-Calculator version used when created the B-Tax conda package.