### PR TITLE
[WIP] CPS as microdata

### DIFF
--- a/btax/get_taxcalc_rates.py
+++ b/btax/get_taxcalc_rates.py
@@ -40,6 +40,12 @@ def get_calculator(baseline, calculator_start_year, reform=None,
     policy1 = Policy()
     if data is not None and "cps" in data:
         records1 = Records.cps_constructor()
+        # impute short and long term capital gains if using CPS data
+        # in 2012 SOI data 6.587% of CG as short-term gains
+        records1.p22250 = 0.06587 * records1.e01100
+        records1.p23250 = (1 - 0.06587) * records1.e01100
+        # set total capital gains to zero
+        records1.e01100 = np.zeros(records1.e01100.shape[0])
     elif data is not None:
         records1 = Records(data=data, weights=weights,
                            start_year=records_start_year)

--- a/btax/get_taxcalc_rates.py
+++ b/btax/get_taxcalc_rates.py
@@ -15,10 +15,10 @@ This py-file creates the following other file(s):
 from __future__ import print_function
 import numpy as np
 from taxcalc import *
-from btax.util import DEFAULT_START_YEAR, RECORDS_START_YEAR
+from btax.util import DEFAULT_START_YEAR, RECORDS_START_YEAR, TC_LAST_YEAR
 
-def get_calculator(baseline, calculator_start_year, reform=None, data=None,
-                   weights=None, records_start_year=None):
+def get_calculator(baseline, calculator_start_year, reform=None,
+                   data=None, weights=None, records_start_year=None):
     '''
     This function creates the tax calculator object for the microsim
 
@@ -38,7 +38,9 @@ def get_calculator(baseline, calculator_start_year, reform=None, data=None,
     '''
     # create a calculator
     policy1 = Policy()
-    if data is not None:
+    if data is not None and "cps" in data:
+        records1 = Records.cps_constructor()
+    elif data is not None:
         records1 = Records(data=data, weights=weights,
                            start_year=records_start_year)
     else:
@@ -54,15 +56,18 @@ def get_calculator(baseline, calculator_start_year, reform=None, data=None,
     # the default set up increments year to 2013
     calc1 = Calculator(records=records1, policy=policy1)
 
-    # this increment_year function extrapolates all PUF variables to the
-    # next year so this step takes the calculator to the start_year
-    for i in range(calculator_start_year-2013):
+    # this increment_year function extrapolates all PUF variables to
+    # the next year so this step takes the calculator to the start_year
+    if calculator_start_year > TC_LAST_YEAR:
+        raise RuntimeError("Start year is beyond data extrapolation.")
+    while calc1.current_year < calculator_start_year:
         calc1.increment_year()
 
     return calc1
 
 
-def get_rates(baseline=False, start_year=DEFAULT_START_YEAR, reform={}):
+def get_rates(baseline=False, start_year=DEFAULT_START_YEAR, reform={},
+              data=None):
     '''
     --------------------------------------------------------------------
     This function computes weighted average marginal tax rates using
@@ -79,8 +84,9 @@ def get_rates(baseline=False, start_year=DEFAULT_START_YEAR, reform={}):
     --------------------------------------------------------------------
     '''
 
-    calc1 = get_calculator(baseline=baseline, calculator_start_year=start_year,
-                           reform=reform)
+    calc1 = get_calculator(baseline=baseline,
+                           calculator_start_year=start_year,
+                           reform=reform, data=data)
 
     # running all the functions and calculates taxes
     calc1.calc_all()

--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -107,7 +107,8 @@ def translate_param_names(start_year=DEFAULT_START_YEAR, **user_mods):
     return user_params
 
 
-def get_params(test_run, baseline, start_year, iit_reform, **user_mods):
+def get_params(test_run, baseline, start_year, iit_reform, data,
+               **user_mods):
     """
     Sets values to all the model parameters.
 
@@ -206,7 +207,7 @@ def get_params(test_run, baseline, start_year, iit_reform, **user_mods):
         assert calc.current_year == start_year
     else:
         from btax.get_taxcalc_rates import get_rates
-        indiv_rates = get_rates(baseline, start_year, iit_reform)
+        indiv_rates = get_rates(baseline, start_year, iit_reform, data)
         tau_nc = indiv_rates['tau_nc']
         tau_div = indiv_rates['tau_div']
         tau_int = indiv_rates['tau_int']

--- a/btax/run_btax.py
+++ b/btax/run_btax.py
@@ -52,7 +52,7 @@ ASSET_PRE_CACHE_FILE = 'asset_data.pkl'
 
 
 def run_btax(test_run, baseline=False, start_year=DEFAULT_START_YEAR,
-             iit_reform=None, **user_params):
+             iit_reform=None, data=None, **user_params):
     """
     Runner script that kicks off the calculations for B-Tax
 
@@ -107,7 +107,7 @@ def run_btax(test_run, baseline=False, start_year=DEFAULT_START_YEAR,
         raise
     # get parameters
     parameters = params.get_params(test_run, baseline, start_year,
-                                   iit_reform, **user_params)
+                                   iit_reform, data, **user_params)
 
     # make calculations by asset and create formated output
     output_by_asset = calc_final_outputs.asset_calcs(parameters,
@@ -121,7 +121,9 @@ def run_btax(test_run, baseline=False, start_year=DEFAULT_START_YEAR,
     return output_by_asset, output_by_industry
 
 
-def run_btax_with_baseline_delta(test_run, start_year, iit_reform,
+def run_btax_with_baseline_delta(test_run,
+                                 start_year=DEFAULT_START_YEAR,
+                                 iit_reform=None, data=None,
                                  **user_params):
     """
     Runner script that kicks off the calculations for B-Tax
@@ -140,7 +142,7 @@ def run_btax_with_baseline_delta(test_run, start_year, iit_reform,
 
     econ_params = filter_user_params_for_econ(**user_params)
     base_output_by_asset, base_output_by_industry = \
-        run_btax(test_run, True, start_year, {}, **econ_params)
+        run_btax(test_run, True, start_year, {}, data=data, **econ_params)
     asset_row_grouping = {}
     subset = zip(*(getattr(base_output_by_asset, at) for at in
                    ('Asset', 'asset_category', 'mettr_c', 'mettr_nc')))
@@ -162,7 +164,7 @@ def run_btax_with_baseline_delta(test_run, start_year, iit_reform,
     row_grouping = {'asset': asset_row_grouping,
                     'industry': industry_row_grouping}
     reform_output_by_asset, reform_output_by_industry =\
-        run_btax(test_run, False, start_year, iit_reform, **user_params)
+        run_btax(test_run, False, start_year, iit_reform, data=data, **user_params)
     changed_output_by_asset =\
         diff_two_tables(reform_output_by_asset, base_output_by_asset)
     changed_output_by_industry =\

--- a/btax/util.py
+++ b/btax/util.py
@@ -11,6 +11,9 @@ DEFAULT_START_YEAR = 2018
 # Start year for tax data (e.g. year of PUF)
 RECORDS_START_YEAR = 2011
 
+# Latest year TaxData extrapolates to
+TC_LAST_YEAR = 2027
+
 
 def to_str(x):
     """


### PR DESCRIPTION
This PR allows B-Tax to read in the CPS file as the micro data used by Tax-Calculator.

One major issue to resolve before this can be merged - it seems that the capital gains variable is missing from the CPS.  This is needed to compute MTRs on capital gains income, an input into the METTR computed by B-Tax.