### PR TITLE
Update versions for Pandas and Tax-Calculator

### DIFF
--- a/btax/pull_soi_proprietorship.py
+++ b/btax/pull_soi_proprietorship.py
@@ -37,7 +37,7 @@ def load_proprietorship_data(entity_dfs):
     # Opening data on depreciable fixed assets, inventories, and land
     # for non-farm sole props
     nonfarm_df = format_dataframe(pd.read_excel(_NFARM_PATH, skiprows=2,
-                                                skip_footer=8))
+                                                skipfooter=8))
     # Cuts off the repeated columns so only the data for all sole props
     # remains
     nonfarm_df = nonfarm_df.T.groupby(sort=False, level=0).first().T
@@ -53,7 +53,7 @@ def load_proprietorship_data(entity_dfs):
 
     # Opens the nonfarm inventory data
     nonfarm_inv = prt.format_excel(pd.read_excel(_NFARM_INV, skiprows=1,
-                                                 skip_footer=8))
+                                                 skipfooter=8))
     # Cuts off the repeated columns so only the data for all sole props remains
     nonfarm_inv = nonfarm_inv.T.groupby(sort=False, level=0).first().T
     nonfarm_inv.columns = [to_str(c) for c in nonfarm_inv.columns]

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,9 @@ name: btax-dev
 channels:
 - ospc
 dependencies:
-- taxcalc>=0.15.0
+- taxcalc>=0.22.0
 - numpy >=1.12.1
-- pandas >=0.22.0
+- pandas >=0.23.4
 - numba
 - toolz
 - six

--- a/run_examples/2017_law.json
+++ b/run_examples/2017_law.json
@@ -1,6 +1,6 @@
 // Title: 2017-law policy extrapolated into the future as if under pre-TCJA law
 // Reform_File_Author: Martin Holmer and Cody Kallen
-// Reform_Reference: 
+// Reform_Reference:
 // Reform_Baseline: current_law_policy.json
 // Reform_Description:
 // - Switch to unchained CPI-U calculation of 2018+ policy parameter values (0)
@@ -15,7 +15,7 @@
 // - 1: _II_rt? and _PT_rt?
 // - 2: four _PT_excl_* parameters
 // - 3: _CTC_c and _CTC_ps and _ACTC_Income_thd
-// - 4: four different _DependentCredit_* parameters
+// - 4: three different _DependentCredit_* parameters
 // - 5: three _ALD_* parameters
 // - 6: seven different _ID_* parameters
 // NOTE: this reform projects pre-TCJA 2017 parameter values forward using the
@@ -46,8 +46,7 @@
         "_ACTC_Income_thd": {"2018": [3000.0]},
         "_DependentCredit_Child_c": {"2018": [0.0]},
         "_DependentCredit_Nonchild_c": {"2018": [0.0]},
-        "_DependentCredit_Nonchild_c": {"2018": [0.0]},
-        "_DependentCredit_before_CTC": {"2018": [0.0]},
+        "_DependentCredit_before_CTC": {"2018": [false]},
         "_ALD_AlimonyPaid_hc": {"2019": [0.0]},
         "_ALD_AlimonyReceived_hc": {"2019": [1.0]},
         "_ALD_DomesticProduction_hc": {"2018": [0.0]},


### PR DESCRIPTION
This PR updates the `environment.yml` to pin to more recent versions of Pandas and Tax-Calculator.  It also updates the `2017_law.json` to work with Tax-Calculator 0.22.1.  Finally, it updates a kwarg for skipping footers when reading excel files to avoid errors.  

This addresses the issues in Issue #214 and Issue #215.