### PR TITLE
Updates to meta.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ install:
 
 script:
   - python -c "from btax import *" && echo B-Tax can be imported
-  - py.test -m "not slow and not needs_puf" ${BTAX_CUR_DIR}/tests
-
+  - py.test -m "not slow and not needs_puf and not local" ${BTAX_CUR_DIR}/tests

--- a/btax/tests/test_4package.py
+++ b/btax/tests/test_4package.py
@@ -1,0 +1,62 @@
+"""
+Tests for package existence and dependencies consistency.
+"""
+# CODING-STYLE CHECKS:
+# pycodestyle test_4package.py
+# pylint --disable=locally-disabled test_4package.py
+
+import os
+import re
+import subprocess
+import yaml
+import pytest
+
+
+TESTS_PATH = os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.mark.local
+def test_for_package_existence():
+    """
+    Ensure that no conda btax package is installed when running pytest.
+    Primarily to help developers catch mistaken installations of btax;
+    the local mark prevents test from running on GitHub.
+    """
+    out = subprocess.check_output(['conda', 'list', 'btax']).decode('ascii')
+    envless_out = out.replace('btax-dev', 'environment')
+    if re.search('btax', envless_out) is not None:
+        assert 'btax package' == 'installed'
+
+
+def test_for_consistency(tests_path=TESTS_PATH):
+    """
+    Ensure that there is consistency between environment.yml dependencies
+    and conda.recipe/meta.yaml requirements.
+    """
+    dev_pkgs = set([
+        'pytest',
+        'pytest-pep8',
+        'pytest-xdist',
+        'mock',
+        'pycodestyle',
+        'pylint',
+        'coverage'
+    ])
+    # read conda.recipe/meta.yaml requirements
+    meta_file = os.path.join(tests_path, '..', '..',
+                             'conda.recipe', 'meta.yaml')
+    with open(meta_file, 'r') as stream:
+        meta = yaml.load(stream)
+    bld = set(meta['requirements']['build'])
+    run = set(meta['requirements']['run'])
+    # confirm conda.recipe/meta.yaml build and run requirements are the same
+    assert bld == run
+    # read environment.yml dependencies
+    envr_file = os.path.join(tests_path, '..', '..',
+                             'environment.yml')
+    with open(envr_file, 'r') as stream:
+        envr = yaml.load(stream)
+    env = set(envr['dependencies'])
+    # confirm that extras in env (relative to run) equal the dev_pkgs set
+    extras = env - run
+    assert extras == dev_pkgs

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,6 @@ requirements:
     - taxcalc
     - setuptools
     - scipy
-    - pytest
     - xlrd
 
   run:
@@ -19,7 +18,6 @@ requirements:
     - taxcalc
     - setuptools
     - scipy
-    - pytest
     - xlrd
 
 about:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,32 +1,26 @@
 package:
   name: btax
-  version: {{ environ.get("GIT_DESCRIBE_TAG", "NOTAG")}}
+  version: 0.0.0
 
 source:
   path: ..
 
 requirements:
   build:
+    - python=3.6
+    - taxcalc
     - setuptools
     - scipy
-    - taxcalc
-    - numpy >=1.12.1
-    - pandas >=0.20.1
-    - python
     - pytest
     - xlrd
-    - bokeh >=0.12.3
 
   run:
+    - python=3.6
+    - taxcalc
     - setuptools
     - scipy
-    - taxcalc
-    - numpy >=1.12.1
-    - pandas >=0.20.1
-    - python
     - pytest
     - xlrd
-    - bokeh >=0.12.3
 
 about:
   home: https://github.com/open-source-economics/B-Tax/

--- a/environment.yml
+++ b/environment.yml
@@ -2,17 +2,15 @@ name: btax-dev
 channels:
 - ospc
 dependencies:
-- taxcalc>=0.22.0
-- numpy >=1.12.1
-- pandas >=0.23.4
-- numba
-- toolz
-- six
-- bokeh >=0.12.3
-- mock
-- pep8
-- pylint
-- coverage
+- python=3.6
+- taxcalc
+- setuptools
+- scipy
+- xlrd
+- pytest
 - pytest-pep8
 - pytest-xdist
-- xlrd
+- mock
+- pycodestyle
+- pylint
+- coverage


### PR DESCRIPTION
This PR updates the `meta.yaml` file used to build the B-Tax package so that it properly specifies how to determine the package version.  This error was pointed out by @martinholmer in Issue #221.  

The `meta.yaml` file also simplifies package dependencies as noted in [this comment](https://github.com/open-source-economics/Behavioral-Responses/pull/18#issue-228848719).